### PR TITLE
Security 설정과 JWT 인증/인가 처리 구현, 심플하게 멤버 도메인 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,11 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     testImplementation("org.springframework.security:spring-security-test")
 
+    // jjwt
+    implementation("io.jsonwebtoken:jjwt-api:0.11.2")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.2")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.2")
+
     // kotlin
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,11 @@ dependencies {
         exclude(group = "org.mockito")
     }
     testImplementation("com.ninja-squad:springmockk:3.0.1")
+
+    // kotest
+    testImplementation("io.kotest:kotest-runner-junit5:5.2.1") // for kotest framework
+    testImplementation("io.kotest:kotest-assertions-core:5.2.1") // for kotest core jvm assertions
+    testImplementation("io.kotest:kotest-property:5.2.1") // for kotest property test
 }
 
 tasks.withType<KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,8 @@ repositories {
     mavenCentral()
 }
 
+val kotestVersion = "5.2.1"
+
 dependencies {
     // web
     implementation("org.springframework.boot:spring-boot-starter-actuator")
@@ -59,9 +61,10 @@ dependencies {
     testImplementation("com.ninja-squad:springmockk:3.0.1")
 
     // kotest
-    testImplementation("io.kotest:kotest-runner-junit5:5.2.1") // for kotest framework
-    testImplementation("io.kotest:kotest-assertions-core:5.2.1") // for kotest core jvm assertions
-    testImplementation("io.kotest:kotest-property:5.2.1") // for kotest property test
+    testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion") // for kotest framework
+    testImplementation("io.kotest:kotest-assertions-core:$kotestVersion") // for kotest core jvm assertions
+    testImplementation("io.kotest:kotest-property:$kotestVersion") // for kotest property test
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.0") // spring extensions
 }
 
 tasks.withType<KotlinCompile> {
@@ -87,6 +90,8 @@ configurations {
 }
 
 extra["snippetsDir"] = file("build/generated-snippets")
+
+extra["kotlin-coroutines.version"] = "1.6.0"
 
 tasks.test {
     project.property("snippetsDir")?.let { outputs.dir(it) }

--- a/src/main/kotlin/com/mojh/cms/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/mojh/cms/common/config/SecurityConfig.kt
@@ -6,6 +6,7 @@ import com.mojh.cms.security.PERMIT_ALL_GET_URI
 import com.mojh.cms.security.PERMIT_ALL_POST_URI
 import org.springframework.context.annotation.Bean
 import org.springframework.http.HttpMethod
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
@@ -16,6 +17,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 
 @EnableWebSecurity
+@EnableGlobalMethodSecurity(securedEnabled = true)
 class SecurityConfig(
     private val jwtAuthenticationFilter: JwtAuthenticationFilter,
     private val jwtAuthenticationEntryPoint: JwtAuthenticationEntryPoint

--- a/src/main/kotlin/com/mojh/cms/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/mojh/cms/common/config/SecurityConfig.kt
@@ -39,5 +39,5 @@ class SecurityConfig(
     }
 
     @Bean
-    fun passwordEncoder(): BCryptPasswordEncoder = BCryptPasswordEncoder()
+    fun passwordEncoder() = BCryptPasswordEncoder()
 }

--- a/src/main/kotlin/com/mojh/cms/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/mojh/cms/common/config/SecurityConfig.kt
@@ -1,9 +1,9 @@
 package com.mojh.cms.common.config
 
-import com.mojh.cms.security.jwt.JwtAuthenticationEntryPoint
-import com.mojh.cms.security.jwt.JwtAuthenticationFilter
 import com.mojh.cms.security.PERMIT_ALL_GET_URI
 import com.mojh.cms.security.PERMIT_ALL_POST_URI
+import com.mojh.cms.security.jwt.JwtAuthenticationEntryPoint
+import com.mojh.cms.security.jwt.JwtAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity

--- a/src/main/kotlin/com/mojh/cms/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/mojh/cms/common/config/SecurityConfig.kt
@@ -1,13 +1,25 @@
 package com.mojh.cms.common.config
 
+import com.mojh.cms.security.jwt.JwtAuthenticationEntryPoint
+import com.mojh.cms.security.jwt.JwtAuthenticationFilter
+import com.mojh.cms.security.PERMIT_ALL_GET_URI
+import com.mojh.cms.security.PERMIT_ALL_POST_URI
+import org.springframework.context.annotation.Bean
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.config.web.servlet.invoke
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
 
 @EnableWebSecurity
-class SecurityConfig : WebSecurityConfigurerAdapter() {
+class SecurityConfig(
+    private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+    private val jwtAuthenticationEntryPoint: JwtAuthenticationEntryPoint
+) : WebSecurityConfigurerAdapter() {
 
     override fun configure(http: HttpSecurity) {
         http {
@@ -15,8 +27,17 @@ class SecurityConfig : WebSecurityConfigurerAdapter() {
             csrf { disable() }
             sessionManagement { SessionCreationPolicy.STATELESS }
             authorizeRequests {
-                authorize(anyRequest, permitAll)
+                PERMIT_ALL_GET_URI.forEach { authorize(HttpMethod.GET, it, permitAll) }
+                PERMIT_ALL_POST_URI.forEach { authorize(HttpMethod.POST, it, permitAll) }
+                authorize(anyRequest, authenticated)
+            }
+            addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+            exceptionHandling {
+                authenticationEntryPoint = jwtAuthenticationEntryPoint
             }
         }
     }
+
+    @Bean
+    fun passwordEncoder(): BCryptPasswordEncoder = BCryptPasswordEncoder()
 }

--- a/src/main/kotlin/com/mojh/cms/common/exception/CustomException.kt
+++ b/src/main/kotlin/com/mojh/cms/common/exception/CustomException.kt
@@ -1,5 +1,14 @@
 package com.mojh.cms.common.exception
 
-open class CustomException(val errorCode: ErrorCode) : RuntimeException() {
+open class CustomException : RuntimeException {
+    val errorCode: ErrorCode
 
+    constructor(errorCode: ErrorCode) : super(errorCode.message) {
+        this.errorCode = errorCode
+    }
+
+    constructor(errorCode: ErrorCode, cause: Throwable) : super(errorCode.message, cause) {
+        this.errorCode = errorCode
+    }
 }
+

--- a/src/main/kotlin/com/mojh/cms/common/exception/CustomException.kt
+++ b/src/main/kotlin/com/mojh/cms/common/exception/CustomException.kt
@@ -7,8 +7,13 @@ open class CustomException : RuntimeException {
         this.errorCode = errorCode
     }
 
-    constructor(errorCode: ErrorCode, cause: Throwable) : super(errorCode.message, cause) {
+    constructor(errorCode: ErrorCode, cause: Throwable) : super(cause) {
         this.errorCode = errorCode
+    }
+
+    override fun toString(): String {
+        val s = javaClass.name
+        return s + ": " + errorCode.message + cause?.let { "\ncause: " + cause.toString() }
     }
 }
 

--- a/src/main/kotlin/com/mojh/cms/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/mojh/cms/common/exception/ErrorCode.kt
@@ -15,10 +15,11 @@ enum class ErrorCode(
     DUPLICATE_ACCOUNT_ID(BAD_REQUEST, "101", "중복된 계정 ID 입니다."),
     WRONG_ACCOUNT_ID(UNAUTHORIZED, "102", "잘못된 계정 ID를 입력했습니다."),
     PASSWORD_NOT_MATCHED(UNAUTHORIZED, "103", "비밀번호가 일치하지 않습니다."),
-    
-    LOGIN_REQUIRED(UNAUTHORIZED, "104", "로그인이 필요합니다."),
+
+    NEED_TO_LOGIN_AGAIN(UNAUTHORIZED, "104", "다시 로그인해야 합니다."),
     INVALID_TOKEN(UNAUTHORIZED, "105", "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(UNAUTHORIZED, "106", "만료된 토큰입니다."),
+    ALREADY_LOGGED_OUT_MEMBER(UNAUTHORIZED, "107", "이미 로그아웃 처리된 멤버입니다."),
 
     // coupon
     COUPON_NOT_FOUND(NOT_FOUND, "200", "해당 쿠폰 정보를 찾을 수 없습니다")

--- a/src/main/kotlin/com/mojh/cms/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/mojh/cms/common/exception/ErrorCode.kt
@@ -1,8 +1,7 @@
 package com.mojh.cms.common.exception
 
 import org.springframework.http.HttpStatus
-import org.springframework.http.HttpStatus.BAD_REQUEST
-import org.springframework.http.HttpStatus.NOT_FOUND
+import org.springframework.http.HttpStatus.*
 
 enum class ErrorCode(
     val status: HttpStatus,
@@ -14,6 +13,9 @@ enum class ErrorCode(
     // member & auth
     MEMBER_NOT_FOUND(NOT_FOUND, "100", "해당 멤버를 찾을 수 없습니다"),
     DUPLICATE_ACCOUNT_ID(BAD_REQUEST, "101", "중복된 계정 ID 입니다."),
+    WRONG_ACCOUNT_ID(UNAUTHORIZED, "102", "잘못된 계정 ID를 입력했습니다."),
+    PASSWORD_NOT_MATCHED(UNAUTHORIZED, "103", "비밀번호가 일치하지 않습니다."),
+
 
     // coupon
     COUPON_NOT_FOUND(NOT_FOUND, "200", "해당 쿠폰 정보를 찾을 수 없습니다")

--- a/src/main/kotlin/com/mojh/cms/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/mojh/cms/common/exception/ErrorCode.kt
@@ -10,7 +10,7 @@ enum class ErrorCode(
 ) {
     // common
 
-    // member
+    // member & auth
     MEMBER_NOT_FOUND(NOT_FOUND, "100", "해당 멤버를 찾을 수 없습니다"),
 
     // coupon

--- a/src/main/kotlin/com/mojh/cms/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/mojh/cms/common/exception/ErrorCode.kt
@@ -15,7 +15,10 @@ enum class ErrorCode(
     DUPLICATE_ACCOUNT_ID(BAD_REQUEST, "101", "중복된 계정 ID 입니다."),
     WRONG_ACCOUNT_ID(UNAUTHORIZED, "102", "잘못된 계정 ID를 입력했습니다."),
     PASSWORD_NOT_MATCHED(UNAUTHORIZED, "103", "비밀번호가 일치하지 않습니다."),
-
+    
+    LOGIN_REQUIRED(UNAUTHORIZED, "104", "로그인이 필요합니다."),
+    INVALID_TOKEN(UNAUTHORIZED, "105", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(UNAUTHORIZED, "106", "만료된 토큰입니다."),
 
     // coupon
     COUPON_NOT_FOUND(NOT_FOUND, "200", "해당 쿠폰 정보를 찾을 수 없습니다")

--- a/src/main/kotlin/com/mojh/cms/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/mojh/cms/common/exception/ErrorCode.kt
@@ -1,6 +1,7 @@
 package com.mojh.cms.common.exception
 
 import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.NOT_FOUND
 
 enum class ErrorCode(
@@ -12,6 +13,7 @@ enum class ErrorCode(
 
     // member & auth
     MEMBER_NOT_FOUND(NOT_FOUND, "100", "해당 멤버를 찾을 수 없습니다"),
+    DUPLICATE_ACCOUNT_ID(BAD_REQUEST, "101", "중복된 계정 ID 입니다."),
 
     // coupon
     COUPON_NOT_FOUND(NOT_FOUND, "200", "해당 쿠폰 정보를 찾을 수 없습니다")

--- a/src/main/kotlin/com/mojh/cms/coupon/controller/CouponController.kt
+++ b/src/main/kotlin/com/mojh/cms/coupon/controller/CouponController.kt
@@ -19,14 +19,14 @@ class CouponController(
 ) {
 
     @PostMapping("/coupons")
-    @Secured("SELLER")
+    @Secured("ROLE_SELLER")
     fun createCoupon(@Valid @RequestBody createCouponRequest: CreateCouponRequest,
                      @LoginMember seller: Member) {
         couponService.createCoupon(createCouponRequest, seller)
     }
 
     @PostMapping("/coupons/{couponInfoId}/download")
-    @Secured("CUSTOMER")
+    @Secured("ROLE_CUSTOMER")
     fun downloadCoupon(@PathVariable couponInfoId: Long,
                        @LoginMember customer: Member): ApiResponse<MemberCouponResponse> {
         return ApiResponse.succeed(couponService.downloadCoupon(couponInfoId, customer))

--- a/src/main/kotlin/com/mojh/cms/coupon/controller/CouponController.kt
+++ b/src/main/kotlin/com/mojh/cms/coupon/controller/CouponController.kt
@@ -1,10 +1,12 @@
 package com.mojh.cms.coupon.controller
 
 import com.mojh.cms.common.ApiResponse
-import com.mojh.cms.coupon.dto.MemberCouponResponse
 import com.mojh.cms.coupon.dto.CreateCouponRequest
+import com.mojh.cms.coupon.dto.MemberCouponResponse
 import com.mojh.cms.coupon.service.CouponService
 import com.mojh.cms.member.entity.Member
+import com.mojh.cms.security.LoginMember
+import org.springframework.security.access.annotation.Secured
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -16,14 +18,17 @@ class CouponController(
     private val couponService: CouponService
 ) {
 
-    @PostMapping("/coupon")
-    fun createCoupon(@Valid @RequestBody createCouponRequest: CreateCouponRequest, admin: Member) {
-        couponService.createCoupon(createCouponRequest, admin)
+    @PostMapping("/coupons")
+    @Secured("SELLER")
+    fun createCoupon(@Valid @RequestBody createCouponRequest: CreateCouponRequest,
+                     @LoginMember seller: Member) {
+        couponService.createCoupon(createCouponRequest, seller)
     }
 
     @PostMapping("/coupons/{couponInfoId}/download")
-//    fun downloadCoupon(@PathVariable couponInfoId: Long, customer: Member): ApiResponse<CouponResponse> {
-    fun downloadCoupon(@PathVariable couponInfoId: Long): ApiResponse<MemberCouponResponse> {
-        return ApiResponse.succeed(couponService.downloadCoupon(couponInfoId))
+    @Secured("CUSTOMER")
+    fun downloadCoupon(@PathVariable couponInfoId: Long,
+                       @LoginMember customer: Member): ApiResponse<MemberCouponResponse> {
+        return ApiResponse.succeed(couponService.downloadCoupon(couponInfoId, customer))
     }
 }

--- a/src/main/kotlin/com/mojh/cms/coupon/service/CouponService.kt
+++ b/src/main/kotlin/com/mojh/cms/coupon/service/CouponService.kt
@@ -2,9 +2,8 @@ package com.mojh.cms.coupon.service
 
 import com.mojh.cms.common.exception.CustomException
 import com.mojh.cms.common.exception.ErrorCode.COUPON_NOT_FOUND
-import com.mojh.cms.common.exception.ErrorCode.MEMBER_NOT_FOUND
-import com.mojh.cms.coupon.dto.MemberCouponResponse
 import com.mojh.cms.coupon.dto.CreateCouponRequest
+import com.mojh.cms.coupon.dto.MemberCouponResponse
 import com.mojh.cms.coupon.entity.MemberCoupon
 import com.mojh.cms.coupon.repository.CouponRepository
 import com.mojh.cms.coupon.repository.MemberCouponRepository
@@ -18,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional
 class CouponService(
     private val couponRepository: CouponRepository,
     private val memberCouponRepository: MemberCouponRepository,
-    private val memberRepository: MemberRepository
 ) {
 
     @Transactional
@@ -27,13 +25,9 @@ class CouponService(
     }
 
     @Transactional
-    fun downloadCoupon(couponInfoId: Long): MemberCouponResponse {
+    fun downloadCoupon(couponInfoId: Long, customer: Member): MemberCouponResponse {
         val couponInfo = couponRepository.findByIdOrNull(couponInfoId)
             ?: throw CustomException(COUPON_NOT_FOUND)
-
-        // security 추가하면 빠질 코드
-        val customer = memberRepository.findByIdOrNull(1L)
-            ?: throw CustomException(MEMBER_NOT_FOUND)
 
         val coupon = MemberCoupon(customer, couponInfo)
         memberCouponRepository.save(coupon)

--- a/src/main/kotlin/com/mojh/cms/member/controller/AuthController.kt
+++ b/src/main/kotlin/com/mojh/cms/member/controller/AuthController.kt
@@ -1,7 +1,0 @@
-package com.mojh.cms.member.controller
-
-import org.springframework.web.bind.annotation.RestController
-
-@RestController
-class AuthController {
-}

--- a/src/main/kotlin/com/mojh/cms/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/mojh/cms/member/controller/MemberController.kt
@@ -1,7 +1,21 @@
 package com.mojh.cms.member.controller
 
-import org.springframework.web.bind.annotation.RestController
+import com.mojh.cms.common.ApiResponse
+import com.mojh.cms.member.dto.SignupMemberRequest
+import com.mojh.cms.member.service.MemberService
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+import javax.validation.Valid
 
 @RestController
-class MemberController {
+@RequestMapping("/member")
+class MemberController(
+    private val memberService: MemberService
+) {
+    @PostMapping("/signup")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun signup(@Valid @RequestBody signupMemberRequest: SignupMemberRequest): ApiResponse<*> {
+        memberService.signup(signupMemberRequest)
+        return ApiResponse.succeed()
+    }
 }

--- a/src/main/kotlin/com/mojh/cms/member/dto/MemberRequestDtos.kt
+++ b/src/main/kotlin/com/mojh/cms/member/dto/MemberRequestDtos.kt
@@ -17,7 +17,7 @@ data class SignupMemberRequest(
     @field:NotNull
     val role: Member.Role
 ) {
-    fun convertToMember(encodedPassword: String) = Member(
+    fun toMember(encodedPassword: String) = Member(
         accountId = this.accountId,
         password = encodedPassword,
         role = this.role

--- a/src/main/kotlin/com/mojh/cms/member/dto/MemberRequestDtos.kt
+++ b/src/main/kotlin/com/mojh/cms/member/dto/MemberRequestDtos.kt
@@ -1,0 +1,25 @@
+package com.mojh.cms.member.dto
+
+import com.mojh.cms.member.entity.Member
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Size
+
+data class SignupMemberRequest(
+    @field:NotBlank
+    @field:Size(min = 5, max = 16)
+    val accountId: String,
+
+    @field:NotBlank
+    @field:Size(min = 6, max = 20)
+    val password: String,
+
+    @field:NotNull
+    val role: Member.Role
+) {
+    fun convertToMember(encodedPassword: String) = Member(
+        accountId = this.accountId,
+        password = encodedPassword,
+        role = this.role
+    )
+}

--- a/src/main/kotlin/com/mojh/cms/member/entity/Member.kt
+++ b/src/main/kotlin/com/mojh/cms/member/entity/Member.kt
@@ -30,6 +30,6 @@ class Member(
         protected set
 
     enum class Role {
-        CUSTOMER, SELLER
+        ROLE_CUSTOMER, ROLE_SELLER
     }
 }

--- a/src/main/kotlin/com/mojh/cms/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/mojh/cms/member/repository/MemberRepository.kt
@@ -4,5 +4,6 @@ import com.mojh.cms.member.entity.Member
 import org.springframework.data.repository.CrudRepository
 
 interface MemberRepository : CrudRepository<Member, Long> {
+    fun existsByAccountId(accountId: String): Boolean
     fun findByAccountId(accountId: String): Member?
 }

--- a/src/main/kotlin/com/mojh/cms/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/mojh/cms/member/repository/MemberRepository.kt
@@ -4,4 +4,5 @@ import com.mojh.cms.member.entity.Member
 import org.springframework.data.repository.CrudRepository
 
 interface MemberRepository : CrudRepository<Member, Long> {
+    fun findByAccountId(accountId: String): Member?
 }

--- a/src/main/kotlin/com/mojh/cms/member/service/AuthService.kt
+++ b/src/main/kotlin/com/mojh/cms/member/service/AuthService.kt
@@ -1,7 +1,0 @@
-package com.mojh.cms.member.service
-
-import org.springframework.stereotype.Service
-
-@Service
-class AuthService {
-}

--- a/src/main/kotlin/com/mojh/cms/member/service/MemberService.kt
+++ b/src/main/kotlin/com/mojh/cms/member/service/MemberService.kt
@@ -21,7 +21,7 @@ class MemberService(
         }
 
         passwordEncoder.encode(signupMemberRequest.password).let {
-            memberRepository.save(signupMemberRequest.convertToMember(it))
+            memberRepository.save(signupMemberRequest.toMember(it))
         }
     }
 }

--- a/src/main/kotlin/com/mojh/cms/member/service/MemberService.kt
+++ b/src/main/kotlin/com/mojh/cms/member/service/MemberService.kt
@@ -1,7 +1,27 @@
 package com.mojh.cms.member.service
 
+import com.mojh.cms.common.exception.CustomException
+import com.mojh.cms.common.exception.ErrorCode.DUPLICATE_ACCOUNT_ID
+import com.mojh.cms.member.dto.SignupMemberRequest
+import com.mojh.cms.member.repository.MemberRepository
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
-class MemberService {
+class MemberService(
+    private val memberRepository: MemberRepository,
+    private val passwordEncoder: PasswordEncoder
+) {
+
+    @Transactional
+    fun signup(signupMemberRequest: SignupMemberRequest) {
+        if (memberRepository.existsByAccountId(signupMemberRequest.accountId)) {
+            throw CustomException(DUPLICATE_ACCOUNT_ID)
+        }
+
+        passwordEncoder.encode(signupMemberRequest.password).let {
+            memberRepository.save(signupMemberRequest.convertToMember(it))
+        }
+    }
 }

--- a/src/main/kotlin/com/mojh/cms/security/JwtTokenUtil.kt
+++ b/src/main/kotlin/com/mojh/cms/security/JwtTokenUtil.kt
@@ -24,12 +24,12 @@ class JwtTokenUtil {
         Keys.hmacShaKeyFor(SECRET_KEY_RAW.toByteArray())
     }
 
-    fun createAccessToken(id: Long): String {
+    fun createAccessToken(accountId: String): String {
         val now = Date()
         return Jwts.builder()
             .setHeaderParam("typ", "JWT")
             .setSubject("access")
-            .claim("id", id)
+            .claim("id", accountId)
             .setIssuedAt(now)
             .setExpiration(Date(now.time + ACCESS_TOKEN_VALID_TIME))
             .signWith(SECRET_KEY, SignatureAlgorithm.HS512)
@@ -46,13 +46,13 @@ class JwtTokenUtil {
             .compact()
     }
 
-    fun getIdFrom(accessToken: String): Long {
+    fun parseId(accessToken: String): String {
         return Jwts.parserBuilder()
             .requireSubject("access")
             .setSigningKey(SECRET_KEY)
             .build()
             .parseClaimsJws(accessToken)
-            .body["id"] as Long
+            .body["id"] as String
     }
 
     fun validateTokenStatus(token: String): TokenStatus {

--- a/src/main/kotlin/com/mojh/cms/security/JwtTokenUtil.kt
+++ b/src/main/kotlin/com/mojh/cms/security/JwtTokenUtil.kt
@@ -1,0 +1,72 @@
+package com.mojh.cms.security
+
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.security.Keys
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.util.*
+import javax.crypto.SecretKey
+
+@Component
+class JwtTokenUtil {
+    @Value("\${jwt.secret-key}")
+    private val SECRET_KEY_RAW: String = ""
+
+    @Value("\${jwt.access-token-valid-time}")
+    private val ACCESS_TOKEN_VALID_TIME: Long = 0
+
+    @Value("\${jwt.refresh-token-valid-time}")
+    private val REFRESH_TOKEN_VALID_TIME: Long = 0
+
+    private val SECRET_KEY: SecretKey by lazy {
+        Keys.hmacShaKeyFor(SECRET_KEY_RAW.toByteArray())
+    }
+
+    fun createAccessToken(id: Long): String {
+        val now = Date()
+        return Jwts.builder()
+            .setHeaderParam("typ", "JWT")
+            .setSubject("access")
+            .claim("id", id)
+            .setIssuedAt(now)
+            .setExpiration(Date(now.time + ACCESS_TOKEN_VALID_TIME))
+            .signWith(SECRET_KEY, SignatureAlgorithm.HS512)
+            .compact()
+    }
+
+    fun createRefreshToken(): String {
+        val now = Date()
+        return Jwts.builder()
+            .setHeaderParam("typ", "JWT")
+            .setIssuedAt(now)
+            .setExpiration(Date(now.time + REFRESH_TOKEN_VALID_TIME))
+            .signWith(SECRET_KEY, SignatureAlgorithm.HS512)
+            .compact()
+    }
+
+    fun getIdFrom(accessToken: String): Long {
+        return Jwts.parserBuilder()
+            .requireSubject("access")
+            .setSigningKey(SECRET_KEY)
+            .build()
+            .parseClaimsJws(accessToken)
+            .body["id"] as Long
+    }
+
+    fun validateTokenStatus(token: String): TokenStatus {
+        return try {
+            Jwts.parserBuilder()
+                .setSigningKey(SECRET_KEY)
+                .build()
+                .parseClaimsJws(token)
+            TokenStatus.VALID
+        } catch (ex: Exception) {
+            when(ex) {
+                is ExpiredJwtException -> TokenStatus.EXPIRED
+                else -> TokenStatus.INVALID
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/mojh/cms/security/LoginMember.kt
+++ b/src/main/kotlin/com/mojh/cms/security/LoginMember.kt
@@ -1,0 +1,9 @@
+package com.mojh.cms.security
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@AuthenticationPrincipal(expression = "member")
+annotation class LoginMember {
+}

--- a/src/main/kotlin/com/mojh/cms/security/MemberAdapter.kt
+++ b/src/main/kotlin/com/mojh/cms/security/MemberAdapter.kt
@@ -1,0 +1,8 @@
+package com.mojh.cms.security
+
+import com.mojh.cms.member.entity.Member
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.User
+
+class MemberAdapter(val member: Member) :
+    User(member.accountId, member.password, listOf(SimpleGrantedAuthority(member.role.toString())))

--- a/src/main/kotlin/com/mojh/cms/security/SecurityConstants.kt
+++ b/src/main/kotlin/com/mojh/cms/security/SecurityConstants.kt
@@ -10,3 +10,7 @@ val PERMIT_ALL_POST_URI = arrayOf(
 )
 
 const val BEARER_PREFIX = "Bearer "
+
+const val ACCESS_TOKEN_REDIS_KEY_PREFIX = "AT:"
+
+const val REFRESH_TOKEN_REDIS_KEY_PREFIX = "RT:"

--- a/src/main/kotlin/com/mojh/cms/security/SecurityConstants.kt
+++ b/src/main/kotlin/com/mojh/cms/security/SecurityConstants.kt
@@ -7,6 +7,7 @@ val PERMIT_ALL_GET_URI = arrayOf(
 val PERMIT_ALL_POST_URI = arrayOf(
     "/member/signup",
     "/auth/login",
+    "/auth/logout",
     "/auth/reissue"
 )
 

--- a/src/main/kotlin/com/mojh/cms/security/SecurityConstants.kt
+++ b/src/main/kotlin/com/mojh/cms/security/SecurityConstants.kt
@@ -1,0 +1,12 @@
+package com.mojh.cms.security
+
+val PERMIT_ALL_GET_URI = arrayOf(
+    "/event/**"
+)
+
+val PERMIT_ALL_POST_URI = arrayOf(
+    "/member/",
+    "/member/login",
+)
+
+const val BEARER_PREFIX = "Bearer "

--- a/src/main/kotlin/com/mojh/cms/security/SecurityConstants.kt
+++ b/src/main/kotlin/com/mojh/cms/security/SecurityConstants.kt
@@ -5,8 +5,8 @@ val PERMIT_ALL_GET_URI = arrayOf(
 )
 
 val PERMIT_ALL_POST_URI = arrayOf(
-    "/member/",
-    "/member/login",
+    "/member/signup",
+    "/auth/login",
 )
 
 const val BEARER_PREFIX = "Bearer "

--- a/src/main/kotlin/com/mojh/cms/security/SecurityConstants.kt
+++ b/src/main/kotlin/com/mojh/cms/security/SecurityConstants.kt
@@ -11,6 +11,8 @@ val PERMIT_ALL_POST_URI = arrayOf(
     "/auth/reissue"
 )
 
+const val AUTH_EXCEPTION_INFO = "AUTH_EXCEPTION_INFO"
+
 const val BEARER_PREFIX = "Bearer "
 
 const val ACCESS_TOKEN_REDIS_KEY_PREFIX = "AT:"

--- a/src/main/kotlin/com/mojh/cms/security/SecurityConstants.kt
+++ b/src/main/kotlin/com/mojh/cms/security/SecurityConstants.kt
@@ -7,6 +7,7 @@ val PERMIT_ALL_GET_URI = arrayOf(
 val PERMIT_ALL_POST_URI = arrayOf(
     "/member/signup",
     "/auth/login",
+    "/auth/reissue"
 )
 
 const val BEARER_PREFIX = "Bearer "

--- a/src/main/kotlin/com/mojh/cms/security/TokenStatus.kt
+++ b/src/main/kotlin/com/mojh/cms/security/TokenStatus.kt
@@ -1,0 +1,5 @@
+package com.mojh.cms.security
+
+enum class TokenStatus {
+    VALID, INVALID, EXPIRED
+}

--- a/src/main/kotlin/com/mojh/cms/security/controller/AuthController.kt
+++ b/src/main/kotlin/com/mojh/cms/security/controller/AuthController.kt
@@ -20,7 +20,7 @@ class AuthController(
         ApiResponse.succeed(authService.login(loginRequest))
 
     @PostMapping("/logout")
-    fun logout(@RequestHeader(AUTHORIZATION) accessToken: String,
+    fun logout(@RequestHeader(AUTHORIZATION) accessToken: String?,
                @Valid @RequestBody logoutRequest: LogoutRequest): ApiResponse<*> {
         authService.logout(accessToken, logoutRequest.refreshToken)
         return ApiResponse.succeed()

--- a/src/main/kotlin/com/mojh/cms/security/controller/AuthController.kt
+++ b/src/main/kotlin/com/mojh/cms/security/controller/AuthController.kt
@@ -2,6 +2,7 @@ package com.mojh.cms.security.controller
 
 import com.mojh.cms.common.ApiResponse
 import com.mojh.cms.member.dto.LoginRequest
+import com.mojh.cms.member.dto.LogoutRequest
 import com.mojh.cms.member.dto.ReissueTokenRequest
 import com.mojh.cms.security.service.AuthService
 import org.springframework.http.HttpHeaders.AUTHORIZATION
@@ -17,6 +18,13 @@ class AuthController(
     @PostMapping("/login")
     fun login(@Valid @RequestBody loginRequest: LoginRequest) =
         ApiResponse.succeed(authService.login(loginRequest))
+
+    @PostMapping("/logout")
+    fun logout(@RequestHeader(AUTHORIZATION) accessToken: String,
+               @Valid @RequestBody logoutRequest: LogoutRequest): ApiResponse<*> {
+        authService.logout(accessToken, logoutRequest.refreshToken)
+        return ApiResponse.succeed()
+    }
 
     @PostMapping("/reissue")
     fun reissueAccessToken(@RequestHeader(AUTHORIZATION) accessToken: String?,

--- a/src/main/kotlin/com/mojh/cms/security/controller/AuthController.kt
+++ b/src/main/kotlin/com/mojh/cms/security/controller/AuthController.kt
@@ -2,7 +2,10 @@ package com.mojh.cms.security.controller
 
 import com.mojh.cms.common.ApiResponse
 import com.mojh.cms.member.dto.LoginRequest
+import com.mojh.cms.member.dto.ReissueTokenRequest
 import com.mojh.cms.security.service.AuthService
+import org.springframework.http.HttpHeaders.AUTHORIZATION
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import javax.validation.Valid
 
@@ -14,4 +17,11 @@ class AuthController(
     @PostMapping("/login")
     fun login(@Valid @RequestBody loginRequest: LoginRequest) =
         ApiResponse.succeed(authService.login(loginRequest))
+
+    @PostMapping("/reissue")
+    fun reissueAccessToken(@RequestHeader(AUTHORIZATION) accessToken: String?,
+                           @Valid @RequestBody reissueTokenRequest: ReissueTokenRequest) =
+        ResponseEntity.ok()
+            .header(AUTHORIZATION, authService.reissueAccessToken(accessToken, reissueTokenRequest.refreshToken))
+            .body(ApiResponse.succeed());
 }

--- a/src/main/kotlin/com/mojh/cms/security/controller/AuthController.kt
+++ b/src/main/kotlin/com/mojh/cms/security/controller/AuthController.kt
@@ -1,0 +1,17 @@
+package com.mojh.cms.security.controller
+
+import com.mojh.cms.common.ApiResponse
+import com.mojh.cms.member.dto.LoginRequest
+import com.mojh.cms.security.service.AuthService
+import org.springframework.web.bind.annotation.*
+import javax.validation.Valid
+
+@RestController
+@RequestMapping("/auth")
+class AuthController(
+    private val authService: AuthService
+) {
+    @PostMapping("/login")
+    fun login(@Valid @RequestBody loginRequest: LoginRequest) =
+        ApiResponse.succeed(authService.login(loginRequest))
+}

--- a/src/main/kotlin/com/mojh/cms/security/dto/AuthRequestDtos.kt
+++ b/src/main/kotlin/com/mojh/cms/security/dto/AuthRequestDtos.kt
@@ -12,3 +12,8 @@ data class LoginRequest(
     @field:Size(min = 6, max = 20)
     val password: String,
 )
+
+data class ReissueTokenRequest(
+    @field:NotBlank
+    val refreshToken: String
+)

--- a/src/main/kotlin/com/mojh/cms/security/dto/AuthRequestDtos.kt
+++ b/src/main/kotlin/com/mojh/cms/security/dto/AuthRequestDtos.kt
@@ -1,0 +1,14 @@
+package com.mojh.cms.member.dto
+
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
+
+data class LoginRequest(
+    @field:NotBlank
+    @field:Size(min = 5, max = 16)
+    val accountId: String,
+
+    @field:NotBlank
+    @field:Size(min = 6, max = 20)
+    val password: String,
+)

--- a/src/main/kotlin/com/mojh/cms/security/dto/AuthRequestDtos.kt
+++ b/src/main/kotlin/com/mojh/cms/security/dto/AuthRequestDtos.kt
@@ -13,6 +13,11 @@ data class LoginRequest(
     val password: String,
 )
 
+data class LogoutRequest(
+    @field:NotBlank
+    val refreshToken: String
+)
+
 data class ReissueTokenRequest(
     @field:NotBlank
     val refreshToken: String

--- a/src/main/kotlin/com/mojh/cms/security/dto/AuthResponseDtos.kt
+++ b/src/main/kotlin/com/mojh/cms/security/dto/AuthResponseDtos.kt
@@ -1,0 +1,6 @@
+package com.mojh.cms.security.dto
+
+data class TokensResponse(
+    val accessToken: String,
+    val refreshToken: String
+)

--- a/src/main/kotlin/com/mojh/cms/security/jwt/JwtAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/mojh/cms/security/jwt/JwtAuthenticationEntryPoint.kt
@@ -2,14 +2,18 @@ package com.mojh.cms.security.jwt
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.mojh.cms.common.ApiResponse
+import com.mojh.cms.common.exception.CustomException
+import com.mojh.cms.security.AUTH_EXCEPTION_INFO
 import org.apache.logging.log4j.LogManager
-import org.springframework.security.web.AuthenticationEntryPoint
-import org.springframework.stereotype.Component
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
 import org.springframework.http.HttpStatus.UNAUTHORIZED
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
 
 @Component
 class JwtAuthenticationEntryPoint(private val objectMapper: ObjectMapper) : AuthenticationEntryPoint {
@@ -17,17 +21,22 @@ class JwtAuthenticationEntryPoint(private val objectMapper: ObjectMapper) : Auth
         private val LOGGER = LogManager.getLogger()
     }
 
-    override fun commence(
-        request: HttpServletRequest,
-        response: HttpServletResponse,
-        authException: AuthenticationException
-    ) {
-        LOGGER.error(authException)
+    override fun commence(request: HttpServletRequest,
+                          response: HttpServletResponse,
+                          authException: AuthenticationException) {
+        val responseBody = request.getAttribute(AUTH_EXCEPTION_INFO)?.let {
+            val ex = it as CustomException
+            LOGGER.warn(ex)
+            objectMapper.writeValueAsString(ApiResponse.failed(ex.errorCode))
+        } ?: {
+            LOGGER.warn(authException)
+            objectMapper.writeValueAsString(ApiResponse.failed(UNAUTHORIZED, authException.message))
+        }
 
         with(response) {
             status = UNAUTHORIZED.value()
             contentType = APPLICATION_JSON_VALUE
-            val responseBody = objectMapper.writeValueAsString(ApiResponse.failed(UNAUTHORIZED, authException.message))
+            characterEncoding = StandardCharsets.UTF_8.name();
             writer.print(responseBody)
         }
     }

--- a/src/main/kotlin/com/mojh/cms/security/jwt/JwtAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/mojh/cms/security/jwt/JwtAuthenticationEntryPoint.kt
@@ -1,0 +1,34 @@
+package com.mojh.cms.security.jwt
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.mojh.cms.common.ApiResponse
+import org.apache.logging.log4j.LogManager
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus.UNAUTHORIZED
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.security.core.AuthenticationException
+
+@Component
+class JwtAuthenticationEntryPoint(private val objectMapper: ObjectMapper) : AuthenticationEntryPoint {
+    companion object {
+        private val LOGGER = LogManager.getLogger()
+    }
+
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException
+    ) {
+        LOGGER.error(authException)
+
+        with(response) {
+            status = UNAUTHORIZED.value()
+            contentType = APPLICATION_JSON_VALUE
+            val responseBody = objectMapper.writeValueAsString(ApiResponse.failed(UNAUTHORIZED, authException.message))
+            writer.print(responseBody)
+        }
+    }
+}

--- a/src/main/kotlin/com/mojh/cms/security/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/mojh/cms/security/jwt/JwtAuthenticationFilter.kt
@@ -29,7 +29,10 @@ class JwtAuthenticationFilter(
         filterChain: FilterChain
     ) {
         jwtTokenUtils.extractTokenFrom(request.getHeader(AUTHORIZATION))?.let{
-            val userAdapter = userDetailsServiceImpl.loadUserByUsername(jwtTokenUtils.parseAccountId(it))
+            val accountId = jwtTokenUtils.parseAccountId(it)
+            jwtTokenUtils.verifyBlockedAccessToken(it, accountId)
+
+            val userAdapter = userDetailsServiceImpl.loadUserByUsername(accountId)
             SecurityContextHolder.getContext().authentication =
                 UsernamePasswordAuthenticationToken(userAdapter, null, userAdapter.authorities)
         }

--- a/src/main/kotlin/com/mojh/cms/security/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/mojh/cms/security/jwt/JwtAuthenticationFilter.kt
@@ -1,0 +1,59 @@
+package com.mojh.cms.security.jwt
+
+import com.mojh.cms.security.BEARER_PREFIX
+import com.mojh.cms.security.PERMIT_ALL_GET_URI
+import com.mojh.cms.security.PERMIT_ALL_POST_URI
+import com.mojh.cms.security.service.UserDetailsServiceImpl
+import org.springframework.http.HttpHeaders.AUTHORIZATION
+import org.springframework.http.HttpMethod
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.util.AntPathMatcher
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.*
+import javax.servlet.FilterChain
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@Component
+class JwtAuthenticationFilter(
+    private val jwtTokenUtils: JwtTokenUtils,
+    private val userDetailsServiceImpl: UserDetailsServiceImpl
+) : OncePerRequestFilter() {
+
+    private val pathMatcher: AntPathMatcher = AntPathMatcher()
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        extractTokenFrom(request)?.let{
+            val userAdapter = userDetailsServiceImpl.loadUserByUsername(jwtTokenUtils.parseId(it))
+            SecurityContextHolder.getContext().authentication =
+                UsernamePasswordAuthenticationToken(userAdapter, null, userAdapter.authorities)
+        }
+
+        filterChain.doFilter(request, response)
+    }
+
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+        return when(request.method) {
+            HttpMethod.GET.toString() -> Arrays.stream(PERMIT_ALL_GET_URI)
+                .anyMatch { path -> pathMatcher.match(path, request.servletPath) }
+            HttpMethod.POST.toString() -> Arrays.stream(PERMIT_ALL_POST_URI)
+                .anyMatch { path -> pathMatcher.match(path, request.servletPath) }
+            else -> false
+        }
+    }
+
+    private fun extractTokenFrom(request: HttpServletRequest): String? {
+        return request.getHeader(AUTHORIZATION)?.run {
+            if(!startsWith(BEARER_PREFIX)) {
+                return null
+            }
+            substring(BEARER_PREFIX.length)
+        }
+    }
+}

--- a/src/main/kotlin/com/mojh/cms/security/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/mojh/cms/security/jwt/JwtAuthenticationFilter.kt
@@ -39,14 +39,12 @@ class JwtAuthenticationFilter(
                     throw CustomException(ErrorCode.ALREADY_LOGGED_OUT_MEMBER)
                 }
 
-                val userAdapter = userDetailsServiceImpl.loadUserByUsername(accountId)
+                val memberAdapter = userDetailsServiceImpl.loadUserByUsername(accountId)
                 SecurityContextHolder.getContext().authentication =
-                    UsernamePasswordAuthenticationToken(userAdapter, null, userAdapter.authorities)
+                    UsernamePasswordAuthenticationToken(memberAdapter, null, memberAdapter.authorities)
             }
         } catch (ex: CustomException) {
             request.setAttribute(AUTH_EXCEPTION_INFO, ex);
-        } catch (ex: Exception) {
-            throw ex
         }
 
         filterChain.doFilter(request, response)

--- a/src/main/kotlin/com/mojh/cms/security/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/mojh/cms/security/jwt/JwtAuthenticationFilter.kt
@@ -1,6 +1,5 @@
 package com.mojh.cms.security.jwt
 
-import com.mojh.cms.security.BEARER_PREFIX
 import com.mojh.cms.security.PERMIT_ALL_GET_URI
 import com.mojh.cms.security.PERMIT_ALL_POST_URI
 import com.mojh.cms.security.service.UserDetailsServiceImpl
@@ -29,8 +28,8 @@ class JwtAuthenticationFilter(
         response: HttpServletResponse,
         filterChain: FilterChain
     ) {
-        extractTokenFrom(request)?.let{
-            val userAdapter = userDetailsServiceImpl.loadUserByUsername(jwtTokenUtils.parseId(it))
+        jwtTokenUtils.extractTokenFrom(request.getHeader(AUTHORIZATION))?.let{
+            val userAdapter = userDetailsServiceImpl.loadUserByUsername(jwtTokenUtils.parseAccountId(it))
             SecurityContextHolder.getContext().authentication =
                 UsernamePasswordAuthenticationToken(userAdapter, null, userAdapter.authorities)
         }
@@ -45,15 +44,6 @@ class JwtAuthenticationFilter(
             HttpMethod.POST.toString() -> Arrays.stream(PERMIT_ALL_POST_URI)
                 .anyMatch { path -> pathMatcher.match(path, request.servletPath) }
             else -> false
-        }
-    }
-
-    private fun extractTokenFrom(request: HttpServletRequest): String? {
-        return request.getHeader(AUTHORIZATION)?.run {
-            if(!startsWith(BEARER_PREFIX)) {
-                return null
-            }
-            substring(BEARER_PREFIX.length)
         }
     }
 }

--- a/src/main/kotlin/com/mojh/cms/security/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/mojh/cms/security/jwt/JwtAuthenticationFilter.kt
@@ -1,5 +1,7 @@
 package com.mojh.cms.security.jwt
 
+import com.mojh.cms.common.exception.CustomException
+import com.mojh.cms.common.exception.ErrorCode
 import com.mojh.cms.security.PERMIT_ALL_GET_URI
 import com.mojh.cms.security.PERMIT_ALL_POST_URI
 import com.mojh.cms.security.service.UserDetailsServiceImpl
@@ -30,7 +32,9 @@ class JwtAuthenticationFilter(
     ) {
         jwtTokenUtils.extractTokenFrom(request.getHeader(AUTHORIZATION))?.let{
             val accountId = jwtTokenUtils.parseAccountId(it)
-            jwtTokenUtils.verifyBlockedAccessToken(it, accountId)
+            if (jwtTokenUtils.isBlockedAccessToken(it, accountId)) {
+                throw CustomException(ErrorCode.ALREADY_LOGGED_OUT_MEMBER)
+            }
 
             val userAdapter = userDetailsServiceImpl.loadUserByUsername(accountId)
             SecurityContextHolder.getContext().authentication =

--- a/src/main/kotlin/com/mojh/cms/security/jwt/JwtTokenUtils.kt
+++ b/src/main/kotlin/com/mojh/cms/security/jwt/JwtTokenUtils.kt
@@ -4,6 +4,7 @@ import com.mojh.cms.common.exception.CustomException
 import com.mojh.cms.common.exception.ErrorCode.*
 import com.mojh.cms.security.ACCESS_TOKEN_REDIS_KEY_PREFIX
 import com.mojh.cms.security.BEARER_PREFIX
+import com.mojh.cms.security.REFRESH_TOKEN_REDIS_KEY_PREFIX
 import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
@@ -125,5 +126,5 @@ class JwtTokenUtils(
         redisson.getSetCache(ACCESS_TOKEN_REDIS_KEY_PREFIX + accountId)
 
     fun getRefreshTokenRSetCache(accountId: String): RSetCache<String> =
-        redisson.getSetCache(ACCESS_TOKEN_REDIS_KEY_PREFIX + accountId)
+        redisson.getSetCache(REFRESH_TOKEN_REDIS_KEY_PREFIX + accountId)
 }

--- a/src/main/kotlin/com/mojh/cms/security/jwt/JwtTokenUtils.kt
+++ b/src/main/kotlin/com/mojh/cms/security/jwt/JwtTokenUtils.kt
@@ -71,12 +71,7 @@ class JwtTokenUtils(
                 .body["id"] as String
         } catch (ex: ExpiredJwtException) {
             // 만료된 AccessToken 재발급에 필요한 로직이라 만료 됐어도 parsing
-            try {
-                ex.claims["id"] as String
-            } catch (ex: Exception) {
-                // Claims안의 값이 null이거나 이상한 값일 수도 있어서 한 번 더 예외 처리
-                throw CustomException(INVALID_TOKEN, ex)
-            }
+            ex.claims["id"] as String
         } catch (ex: Exception) {
             throw CustomException(INVALID_TOKEN, ex)
         }

--- a/src/main/kotlin/com/mojh/cms/security/jwt/JwtTokenUtils.kt
+++ b/src/main/kotlin/com/mojh/cms/security/jwt/JwtTokenUtils.kt
@@ -1,6 +1,9 @@
 package com.mojh.cms.security.jwt
 
+import com.mojh.cms.security.BEARER_PREFIX
+import com.sun.corba.se.impl.oa.poa.AOMEntry.VALID
 import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.JwtException
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
 import io.jsonwebtoken.security.Keys
@@ -8,6 +11,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.util.*
 import javax.crypto.SecretKey
+
 
 @Component
 class JwtTokenUtils {
@@ -46,7 +50,7 @@ class JwtTokenUtils {
             .compact()
     }
 
-    fun parseId(accessToken: String): String {
+    fun parseAccountId(accessToken: String): String {
         return Jwts.parserBuilder()
             .requireSubject("access")
             .setSigningKey(SECRET_KEY)
@@ -67,6 +71,15 @@ class JwtTokenUtils {
                 is ExpiredJwtException -> TokenStatus.EXPIRED
                 else -> TokenStatus.INVALID
             }
+        }
+    }
+
+    fun extractTokenFrom(header: String?): String? {
+        return header?.run {
+            if(!startsWith(BEARER_PREFIX)) {
+                return null
+            }
+            substring(BEARER_PREFIX.length)
         }
     }
 }

--- a/src/main/kotlin/com/mojh/cms/security/jwt/JwtTokenUtils.kt
+++ b/src/main/kotlin/com/mojh/cms/security/jwt/JwtTokenUtils.kt
@@ -91,18 +91,18 @@ class JwtTokenUtils(
             .parseClaimsJws(token)
             .body.expiration.time - Date().time
 
-    fun validateToken(token: String) {
+    fun validateToken(token: String) =
         try {
             Jwts.parserBuilder()
                 .setSigningKey(SECRET_KEY)
                 .build()
                 .parseClaimsJws(token)
+            true
         } catch (ex: Exception) {
             throw CustomException(INVALID_TOKEN, ex)
         } catch (ex: ExpiredJwtException) {
             throw CustomException(EXPIRED_TOKEN, ex)
         }
-    }
 
     /**
      * 이미 로그아웃 처리되어 차단된 access token인지 확인

--- a/src/main/kotlin/com/mojh/cms/security/jwt/JwtTokenUtils.kt
+++ b/src/main/kotlin/com/mojh/cms/security/jwt/JwtTokenUtils.kt
@@ -1,4 +1,4 @@
-package com.mojh.cms.security
+package com.mojh.cms.security.jwt
 
 import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.Jwts
@@ -10,7 +10,7 @@ import java.util.*
 import javax.crypto.SecretKey
 
 @Component
-class JwtTokenUtil {
+class JwtTokenUtils {
     @Value("\${jwt.secret-key}")
     private val SECRET_KEY_RAW: String = ""
 

--- a/src/main/kotlin/com/mojh/cms/security/jwt/TokenStatus.kt
+++ b/src/main/kotlin/com/mojh/cms/security/jwt/TokenStatus.kt
@@ -1,5 +1,0 @@
-package com.mojh.cms.security.jwt
-
-enum class TokenStatus {
-    VALID, INVALID, EXPIRED
-}

--- a/src/main/kotlin/com/mojh/cms/security/jwt/TokenStatus.kt
+++ b/src/main/kotlin/com/mojh/cms/security/jwt/TokenStatus.kt
@@ -1,4 +1,4 @@
-package com.mojh.cms.security
+package com.mojh.cms.security.jwt
 
 enum class TokenStatus {
     VALID, INVALID, EXPIRED

--- a/src/main/kotlin/com/mojh/cms/security/service/AuthService.kt
+++ b/src/main/kotlin/com/mojh/cms/security/service/AuthService.kt
@@ -4,16 +4,16 @@ import com.mojh.cms.common.exception.CustomException
 import com.mojh.cms.common.exception.ErrorCode.*
 import com.mojh.cms.member.dto.LoginRequest
 import com.mojh.cms.member.repository.MemberRepository
+import com.mojh.cms.security.ACCESS_TOKEN_REDIS_KEY_PREFIX
+import com.mojh.cms.security.REFRESH_TOKEN_REDIS_KEY_PREFIX
 import com.mojh.cms.security.dto.TokensResponse
 import com.mojh.cms.security.jwt.JwtTokenUtils
-import com.mojh.cms.security.jwt.TokenStatus
-import org.redisson.api.RedissonClient
+import org.redisson.api.*
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.data.redis.core.ValueOperations
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.util.StringUtils
+import java.util.*
 import java.util.concurrent.TimeUnit
 
 
@@ -27,7 +27,6 @@ class AuthService(
     @Value("\${jwt.refresh-token-valid-time}")
     private val REFRESH_TOKEN_VALID_TIME: Long = 0
 
-
     @Transactional
     fun login(loginRequest: LoginRequest): TokensResponse {
         val member = memberRepository.findByAccountId(loginRequest.accountId)
@@ -40,27 +39,25 @@ class AuthService(
         val accessToken = jwtTokenUtils.createAccessToken(loginRequest.accountId)
         val refreshToken = jwtTokenUtils.createRefreshToken()
 
-        redisson.getBucket<String>(loginRequest.accountId)
-            .set(refreshToken, REFRESH_TOKEN_VALID_TIME, TimeUnit.MILLISECONDS)
+        redisson.getSetCache<String>(REFRESH_TOKEN_REDIS_KEY_PREFIX + loginRequest.accountId)
+            .add(refreshToken, REFRESH_TOKEN_VALID_TIME, TimeUnit.MILLISECONDS)
 
         return TokensResponse(accessToken, refreshToken)
     }
+
+    
 
     @Transactional(readOnly = true)
     fun reissueAccessToken(accessToken: String?, refreshToken: String): String {
         val accountId: String = accessToken?.let { jwtTokenUtils.parseAccountId(it) } ?: throw CustomException(INVALID_TOKEN)
 
-        when (jwtTokenUtils.validateTokenStatus(refreshToken)) {
-            TokenStatus.EXPIRED -> throw CustomException(EXPIRED_TOKEN)
-            TokenStatus.INVALID -> throw CustomException(INVALID_TOKEN)
+        jwtTokenUtils.validateToken(refreshToken)
+
+        val refreshTokenSet = redisson.getSetCache<String>(REFRESH_TOKEN_REDIS_KEY_PREFIX + accountId)
+        if (!refreshTokenSet.contains(refreshToken)) {
+            throw CustomException(LOGIN_REQUIRED)
         }
 
-        redisson.getBucket<String?>(accountId).get()?.let {
-            if (it != refreshToken) {
-                throw CustomException(INVALID_TOKEN)
-            }
-        } ?: throw CustomException(LOGIN_REQUIRED)
-
-        return jwtTokenUtils.createAccessToken(accessToken)
+        return jwtTokenUtils.createAccessToken(accountId)
     }
 }

--- a/src/main/kotlin/com/mojh/cms/security/service/AuthService.kt
+++ b/src/main/kotlin/com/mojh/cms/security/service/AuthService.kt
@@ -44,10 +44,11 @@ class AuthService(
     }
 
     @Transactional
-    fun logout(accessToken: String, refreshToken: String) {
+    fun logout(accessToken: String?, refreshToken: String) {
         jwtTokenUtils.validateToken(refreshToken)
 
-        val accountId = jwtTokenUtils.parseAccountId(accessToken)
+        val accountId: String = accessToken?.let { jwtTokenUtils.parseAccountId(it) } ?: throw CustomException(INVALID_TOKEN)
+        jwtTokenUtils.verifyBlockedAccessToken(accessToken, accountId)
 
         // refresh token redis에서 제거
         val refreshTokenSet = jwtTokenUtils.getRefreshTokenRSetCache(accountId)

--- a/src/main/kotlin/com/mojh/cms/security/service/AuthService.kt
+++ b/src/main/kotlin/com/mojh/cms/security/service/AuthService.kt
@@ -1,0 +1,45 @@
+package com.mojh.cms.security.service
+
+import com.mojh.cms.common.exception.CustomException
+import com.mojh.cms.common.exception.ErrorCode.WRONG_ACCOUNT_ID
+import com.mojh.cms.common.exception.ErrorCode.PASSWORD_NOT_MATCHED
+import com.mojh.cms.member.dto.LoginRequest
+import com.mojh.cms.member.repository.MemberRepository
+import com.mojh.cms.security.dto.TokensResponse
+import com.mojh.cms.security.jwt.JwtTokenUtils
+import org.redisson.api.RedissonClient
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.TimeUnit
+
+@Service
+class AuthService(
+    private val memberRepository: MemberRepository,
+    private val passwordEncoder: PasswordEncoder,
+    private val redisson: RedissonClient,
+    private val jwtTokenUtils: JwtTokenUtils
+) {
+    @Value("\${jwt.refresh-token-valid-time}")
+    private val REFRESH_TOKEN_VALID_TIME: Long = 0
+
+
+    @Transactional
+    fun login(loginRequest: LoginRequest): TokensResponse {
+        val member = memberRepository.findByAccountId(loginRequest.accountId)
+            ?: throw CustomException(WRONG_ACCOUNT_ID)
+
+        if (!passwordEncoder.matches(loginRequest.password, member.password)) {
+            throw CustomException(PASSWORD_NOT_MATCHED)
+        }
+
+        val accessToken = jwtTokenUtils.createAccessToken(loginRequest.accountId)
+        val refreshToken = jwtTokenUtils.createRefreshToken()
+
+        redisson.getBucket<String>(loginRequest.accountId)
+            .set(refreshToken, REFRESH_TOKEN_VALID_TIME, TimeUnit.MILLISECONDS)
+
+        return TokensResponse(accessToken, refreshToken)
+    }
+}

--- a/src/main/kotlin/com/mojh/cms/security/service/AuthService.kt
+++ b/src/main/kotlin/com/mojh/cms/security/service/AuthService.kt
@@ -45,7 +45,7 @@ class AuthService(
         jwtTokenUtils.validateToken(refreshToken)
 
         val accountId: String = accessToken?.let { jwtTokenUtils.parseAccountId(it) } ?: throw CustomException(INVALID_TOKEN)
-        jwtTokenUtils.verifyBlockedAccessToken(accessToken, accountId)
+        jwtTokenUtils.isBlockedAccessToken(accessToken, accountId)
 
         // refresh token redis에서 제거
         val refreshTokenSet = jwtTokenUtils.getRefreshTokenRSetCache(accountId)

--- a/src/main/kotlin/com/mojh/cms/security/service/AuthService.kt
+++ b/src/main/kotlin/com/mojh/cms/security/service/AuthService.kt
@@ -4,11 +4,8 @@ import com.mojh.cms.common.exception.CustomException
 import com.mojh.cms.common.exception.ErrorCode.*
 import com.mojh.cms.member.dto.LoginRequest
 import com.mojh.cms.member.repository.MemberRepository
-import com.mojh.cms.security.ACCESS_TOKEN_REDIS_KEY_PREFIX
-import com.mojh.cms.security.REFRESH_TOKEN_REDIS_KEY_PREFIX
 import com.mojh.cms.security.dto.TokensResponse
 import com.mojh.cms.security.jwt.JwtTokenUtils
-import org.redisson.api.*
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/com/mojh/cms/security/service/UserDetailsServiceImpl.kt
+++ b/src/main/kotlin/com/mojh/cms/security/service/UserDetailsServiceImpl.kt
@@ -1,0 +1,19 @@
+package com.mojh.cms.security.service
+
+import com.mojh.cms.common.exception.CustomException
+import com.mojh.cms.common.exception.ErrorCode
+import com.mojh.cms.member.repository.MemberRepository
+import com.mojh.cms.security.MemberAdapter
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class UserDetailsServiceImpl(private val memberRepository: MemberRepository) : UserDetailsService {
+    override fun loadUserByUsername(accountId: String): UserDetails {
+        return memberRepository.findByAccountId(accountId)?.let {
+            MemberAdapter(it)
+        } ?: throw CustomException(ErrorCode.MEMBER_NOT_FOUND)
+    }
+}

--- a/src/main/kotlin/com/mojh/cms/security/service/UserDetailsServiceImpl.kt
+++ b/src/main/kotlin/com/mojh/cms/security/service/UserDetailsServiceImpl.kt
@@ -6,7 +6,6 @@ import com.mojh.cms.member.repository.MemberRepository
 import com.mojh.cms.security.MemberAdapter
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService
-import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.stereotype.Service
 
 @Service

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -30,3 +30,8 @@ spring:
         show_sql: true
         format_sql: true
         use_sql_comments: true
+
+jwt:
+  secret-key: 'jwttokenlocaltestsecretkey1q2w3e4r!Useasecretkeyofatleast64bytes'
+  access-token-valid-time: 90000 # 테스트용으로 1분 30초, 1.5 * 60 * 1000
+  refresh-token-valid-time: 150000 # 테스트용으로 2분 30초, 2.5 * 60 * 1000

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -31,3 +31,8 @@ spring:
   h2:
     console:
       enabled: true
+
+jwt:
+  secret-key: 'jwttestplocaltestsecretkey1q2w3e4r!Useasecretkeyofatleast64bytes'
+  access-token-valid-time: 90000
+  refresh-token-valid-time: 150000

--- a/src/test/kotlin/com/mojh/cms/common/BaseTest.kt
+++ b/src/test/kotlin/com/mojh/cms/common/BaseTest.kt
@@ -5,5 +5,6 @@ import org.springframework.test.context.TestConstructor
 
 @ActiveProfiles("test")
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
-abstract class BaseTest {
-}
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class BaseTest

--- a/src/test/kotlin/com/mojh/cms/common/UnitTest.kt
+++ b/src/test/kotlin/com/mojh/cms/common/UnitTest.kt
@@ -4,5 +4,5 @@ import io.mockk.junit5.MockKExtension
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(MockKExtension::class)
-abstract class UnitTest : BaseTest() {
-}
+@BaseTest
+annotation class UnitTest

--- a/src/test/kotlin/com/mojh/cms/coupon/service/MemberCouponServiceTest.kt
+++ b/src/test/kotlin/com/mojh/cms/coupon/service/MemberCouponServiceTest.kt
@@ -10,11 +10,15 @@ import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.verify
-import org.junit.jupiter.api.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 import java.time.Month
 
-internal class MemberCouponServiceTest : UnitTest() {
+@UnitTest
+internal class MemberCouponServiceTest {
     @MockK
     private lateinit var couponRepository: CouponRepository
 

--- a/src/test/kotlin/com/mojh/cms/infra/RedissonTest.kt
+++ b/src/test/kotlin/com/mojh/cms/infra/RedissonTest.kt
@@ -8,8 +8,9 @@ import org.redisson.api.RedissonClient
 import org.springframework.boot.test.context.SpringBootTest
 import java.util.concurrent.TimeUnit
 
+@BaseTest
 @SpringBootTest(classes = [RedissonConfig::class])
-class RedissonTest(private val redisson: RedissonClient) : BaseTest() {
+class RedissonTest(private val redisson: RedissonClient) {
 
     @Test
     fun `레디스 데이터 만료 전 조회 성공`() {

--- a/src/test/kotlin/com/mojh/cms/security/jwt/JwtTokenUtilsTest.kt
+++ b/src/test/kotlin/com/mojh/cms/security/jwt/JwtTokenUtilsTest.kt
@@ -1,0 +1,38 @@
+package com.mojh.cms.security.jwt
+
+import com.mojh.cms.common.BaseTest
+import com.mojh.cms.common.config.RedissonConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest(classes = [JwtTokenUtils::class, RedissonConfig::class])
+internal class JwtTokenUtilsTest(
+    private val jwtTokenUtils: JwtTokenUtils
+) : BaseTest() {
+
+    @Test
+    fun `유효한 access token 생성`() {
+        //given
+        val accountId = "account123"
+
+        //when
+        val token = jwtTokenUtils.createAccessToken(accountId)
+        jwtTokenUtils.validateToken(token)
+
+        //then
+        assertThat(token).isNotBlank
+    }
+
+    @Test
+    fun `유효한 refresh token 생성`() {
+        //given
+
+        //when
+        val token = jwtTokenUtils.createRefreshToken()
+        jwtTokenUtils.validateToken(token)
+
+        //then
+        assertThat(token).isNotBlank
+    }
+}

--- a/src/test/kotlin/com/mojh/cms/security/jwt/JwtTokenUtilsTest.kt
+++ b/src/test/kotlin/com/mojh/cms/security/jwt/JwtTokenUtilsTest.kt
@@ -2,43 +2,37 @@ package com.mojh.cms.security.jwt
 
 import com.mojh.cms.common.BaseTest
 import com.mojh.cms.common.config.RedissonConfig
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.util.StringUtils
 
 @BaseTest
 @SpringBootTest(classes = [JwtTokenUtils::class, RedissonConfig::class])
-internal class JwtTokenUtilsTest(private val jwtTokenUtils: JwtTokenUtils) {
+@ContextConfiguration
+internal class JwtTokenUtilsTest(private val jwtTokenUtils: JwtTokenUtils) : FunSpec() {
 
-    private lateinit var accountId: String;
-
-    @BeforeEach
-    internal fun setUp() {
-        accountId = "testAccountId"
+    companion object {
+        private val accountId = "testAccountId";
+        private val jwtHeaderBase64 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.";
     }
 
-    @Test
-    fun `유효한 access token 생성`() {
-        //given
+    init {
 
-        //when
-        val token = jwtTokenUtils.createAccessToken(accountId)
+        test("access token 생성 성공시 유효한 토큰 획득") {
+            val actualAccessToken = jwtTokenUtils.createAccessToken(accountId)
 
-        //then
-        assertThat(token).isNotBlank
-        jwtTokenUtils.validateToken(token)
-    }
+            StringUtils.containsWhitespace(actualAccessToken) shouldBe false
+            actualAccessToken shouldStartWith jwtHeaderBase64
+        }
 
-    @Test
-    fun `유효한 refresh token 생성`() {
-        //given
+        test("refresh token 생성 성공시 유효한 토큰 획득") {
+            val actualRefreshToken = jwtTokenUtils.createRefreshToken()
 
-        //when
-        val token = jwtTokenUtils.createRefreshToken()
-
-        //then
-        assertThat(token).isNotBlank
-        jwtTokenUtils.validateToken(token)
+            StringUtils.containsWhitespace(actualRefreshToken) shouldBe false
+            actualRefreshToken shouldStartWith jwtHeaderBase64
+        }
     }
 }

--- a/src/test/kotlin/com/mojh/cms/security/jwt/JwtTokenUtilsTest.kt
+++ b/src/test/kotlin/com/mojh/cms/security/jwt/JwtTokenUtilsTest.kt
@@ -3,25 +3,31 @@ package com.mojh.cms.security.jwt
 import com.mojh.cms.common.BaseTest
 import com.mojh.cms.common.config.RedissonConfig
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 
+@BaseTest
 @SpringBootTest(classes = [JwtTokenUtils::class, RedissonConfig::class])
-internal class JwtTokenUtilsTest(
-    private val jwtTokenUtils: JwtTokenUtils
-) : BaseTest() {
+internal class JwtTokenUtilsTest(private val jwtTokenUtils: JwtTokenUtils) {
+
+    private lateinit var accountId: String;
+
+    @BeforeEach
+    internal fun setUp() {
+        accountId = "testAccountId"
+    }
 
     @Test
     fun `유효한 access token 생성`() {
         //given
-        val accountId = "account123"
 
         //when
         val token = jwtTokenUtils.createAccessToken(accountId)
-        jwtTokenUtils.validateToken(token)
 
         //then
         assertThat(token).isNotBlank
+        jwtTokenUtils.validateToken(token)
     }
 
     @Test
@@ -30,9 +36,9 @@ internal class JwtTokenUtilsTest(
 
         //when
         val token = jwtTokenUtils.createRefreshToken()
-        jwtTokenUtils.validateToken(token)
 
         //then
         assertThat(token).isNotBlank
+        jwtTokenUtils.validateToken(token)
     }
 }

--- a/src/test/kotlin/com/mojh/cms/security/jwt/JwtTokenUtilsTest.kt
+++ b/src/test/kotlin/com/mojh/cms/security/jwt/JwtTokenUtilsTest.kt
@@ -2,37 +2,280 @@ package com.mojh.cms.security.jwt
 
 import com.mojh.cms.common.BaseTest
 import com.mojh.cms.common.config.RedissonConfig
+import com.mojh.cms.common.exception.CustomException
+import com.mojh.cms.common.exception.ErrorCode
+import com.mojh.cms.security.BEARER_PREFIX
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.longs.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldHaveLength
+import io.kotest.matchers.string.shouldHaveMinLength
 import io.kotest.matchers.string.shouldStartWith
+import org.redisson.api.RSetCache
+import org.redisson.api.RedissonClient
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ContextConfiguration
 import org.springframework.util.StringUtils
 
 @BaseTest
 @SpringBootTest(classes = [JwtTokenUtils::class, RedissonConfig::class])
-@ContextConfiguration
-internal class JwtTokenUtilsTest(private val jwtTokenUtils: JwtTokenUtils) : FunSpec() {
+internal class JwtTokenUtilsTest(
+    private val jwtTokenUtils: JwtTokenUtils,
+    private val redisson: RedissonClient
+) : FunSpec() {
 
     companion object {
-        private val accountId = "testAccountId";
-        private val jwtHeaderBase64 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.";
+        private const val ACCOUNT_ID = "testAccountId";
+        private const val JWT_HEADER_BASE64 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.";
+        private const val EXPIRED_ACCESS_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhY2Nlc3MiLCJpZCI6InRlc3RBY2NvdW50SWQiLCJpYXQiOjE2NDc1MDE1NDYsImV4cCI6MTY0NzUwMTYzNn0.US3LiOA6B4Wtq9PJnxZPBrLJ_SREYVDKkf-wblshSRSI4dlZnnxvB4FyKFLCVRC97LEhivEmPHC4OkkgiHuECg";
+        private const val EXPIRED_REFRESH_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE2NDc1MDI4NzYsImV4cCI6MTY0NzUwMzAyNn0.1RurnEP4bNLxlEZ8CBxvzsSguqxB2lOhfBoIAcMnQGMRs4l-HVwePjbKHWaEKMKGa3WxYE7IMknQuzrrykPB2Q"
+        private const val INVALID_TOKEN = "invalidToken"
     }
 
     init {
+        isolationMode = IsolationMode.InstancePerLeaf
 
-        test("access token 생성 성공시 유효한 토큰 획득") {
-            val actualAccessToken = jwtTokenUtils.createAccessToken(accountId)
 
-            StringUtils.containsWhitespace(actualAccessToken) shouldBe false
-            actualAccessToken shouldStartWith jwtHeaderBase64
+
+        test("액세스 토큰 생성 시 유효한 토큰이 반환된다") {
+            val actualAccessToken = jwtTokenUtils.createAccessToken(ACCOUNT_ID)
+
+            assertSoftly(actualAccessToken) {
+                StringUtils.containsWhitespace(this) shouldBe false
+                this shouldStartWith JWT_HEADER_BASE64
+            }
+
         }
 
-        test("refresh token 생성 성공시 유효한 토큰 획득") {
+        test("리프레쉬 토큰 생성 성공시 유효한 토큰이 반환된다") {
             val actualRefreshToken = jwtTokenUtils.createRefreshToken()
 
-            StringUtils.containsWhitespace(actualRefreshToken) shouldBe false
-            actualRefreshToken shouldStartWith jwtHeaderBase64
+            assertSoftly(actualRefreshToken) {
+                StringUtils.containsWhitespace(this) shouldBe false
+                this shouldStartWith JWT_HEADER_BASE64
+            }
+        }
+
+
+        context("토큰에서 계정 아이디를 파싱한다") {
+            context("액세스 토큰이") {
+                test("유효할 때 파싱 시 계정 아이디가 반환된다") {
+                    val accessToken = jwtTokenUtils.createAccessToken(ACCOUNT_ID)
+
+                    val actualAccountId = jwtTokenUtils.parseAccountId(accessToken)
+
+                    actualAccountId shouldBe ACCOUNT_ID
+                }
+
+                test("만료됐더라도 파싱 시 계정 아이디가 반환된다") {
+                    val actualAccountId = jwtTokenUtils.parseAccountId(EXPIRED_ACCESS_TOKEN)
+
+                    actualAccountId shouldBe ACCOUNT_ID
+                }
+            }
+
+            context("리프레쉬 토큰은") {
+                test("유효하더라도 파싱 시 CustomException 'INVALID_TOKEN'을 던진다") {
+                    val refreshToken = jwtTokenUtils.createRefreshToken()
+
+                    shouldThrow<CustomException> {
+                        jwtTokenUtils.parseAccountId(refreshToken)
+                    }.errorCode shouldBe ErrorCode.INVALID_TOKEN
+                }
+
+                // Jwts에서 requireSubject("access") subject : "access" 인지 확인하기 때문
+                test("만료됐어도 파싱 시 CustomException 'INVALID_TOKEN'을 던진다") {
+                    shouldThrow<CustomException> {
+                        jwtTokenUtils.parseAccountId(EXPIRED_REFRESH_TOKEN)
+                    }.errorCode shouldBe ErrorCode.INVALID_TOKEN
+                }
+            }
+
+            test("유효하지 않은 토큰으로 파싱 시 CustomException 'INVALID_TOKEN'을 던진다") {
+                shouldThrow<CustomException> {
+                    jwtTokenUtils.parseAccountId(INVALID_TOKEN)
+                }.errorCode shouldBe ErrorCode.INVALID_TOKEN
+            }
+        }
+
+        context("토큰의 남은 만료 시간을 반환한다") {
+            context("액세스 토큰이") {
+                test("유효할 때 남은 만료 시간이 반환된다") {
+                    val token = jwtTokenUtils.createAccessToken(ACCOUNT_ID);
+
+                    val actual = jwtTokenUtils.getRemainingExpirationTime(token)
+
+                    actual shouldBeGreaterThan 0
+                }
+
+                test("만료됐으면 남은 만료 시간을 확인할 경우 CustomException 'EXPIRED_TOKEN'을 던진다") {
+                    shouldThrow<CustomException> {
+                        jwtTokenUtils.getRemainingExpirationTime(EXPIRED_ACCESS_TOKEN)
+                    }.errorCode shouldBe ErrorCode.EXPIRED_TOKEN
+                }
+            }
+
+            context("리프레쉬 토큰이") {
+                test("유효할 때 남은 만료 시간이 반환된다") {
+                    val token = jwtTokenUtils.createRefreshToken();
+
+                    val actual = jwtTokenUtils.getRemainingExpirationTime(token)
+
+                    actual shouldBeGreaterThan 0
+                }
+
+                test("만료됐으면 남은 만료 시간을 확인할 경우 CustomException 'EXPIRED_TOKEN'을 던진다") {
+                    shouldThrow<CustomException> {
+                        jwtTokenUtils.getRemainingExpirationTime(EXPIRED_REFRESH_TOKEN)
+                    }.errorCode shouldBe ErrorCode.EXPIRED_TOKEN
+                }
+            }
+
+
+            test("유효하지 않은 토큰으로 남은 만료 시간을 확인할 경우 CustomException 'INVALID_TOKEN'을 던진다") {
+                shouldThrow<CustomException> {
+                    jwtTokenUtils.getRemainingExpirationTime(INVALID_TOKEN)
+                }.errorCode shouldBe ErrorCode.INVALID_TOKEN
+            }
+        }
+
+        context("토큰이 유효한지 확인한다") {
+            context("액세스 토큰이") {
+                test("유효할 때 true가 반환된다") {
+                    val token = jwtTokenUtils.createAccessToken(ACCOUNT_ID);
+
+                    val result = jwtTokenUtils.validateToken(token)
+
+                    result shouldBe true
+                }
+
+                test("만료됐으면 CustomException 'EXPIRED_TOKEN'을 던진다") {
+                    shouldThrow<CustomException> {
+                        jwtTokenUtils.validateToken(EXPIRED_ACCESS_TOKEN)
+                    }.errorCode shouldBe ErrorCode.EXPIRED_TOKEN
+                }
+            }
+
+            context("리프레쉬 토큰이") {
+                test("유효할 때 true가 반환된다") {
+                    val token = jwtTokenUtils.createRefreshToken();
+
+                    val result = jwtTokenUtils.validateToken(token)
+
+                    result shouldBe true
+                }
+
+                test("만료됐으면 CustomException 'EXPIRED_TOKEN'을 던진다") {
+                    shouldThrow<CustomException> {
+                        jwtTokenUtils.validateToken(EXPIRED_REFRESH_TOKEN)
+                    }.errorCode shouldBe ErrorCode.EXPIRED_TOKEN
+                }
+            }
+
+
+            test("유효하지 않은 토큰으로 유효성 검사를 하면 CustomException 'INVALID_TOKEN'을 던진다") {
+                shouldThrow<CustomException> {
+                    jwtTokenUtils.validateToken(INVALID_TOKEN)
+                }.errorCode shouldBe ErrorCode.INVALID_TOKEN
+            }
+        }
+
+        // TODO: test
+        /*context("차단된 액세스 토큰인지 확인한다") {
+            //given
+            val registeredAccessToken = jwtTokenUtils.createAccessToken(ACCOUNT_ID)
+            // access token blacklist 등록
+            redisson.getSetCache<String>(ACCESS_TOKEN_REDIS_KEY_PREFIX + ACCOUNT_ID)
+                .add(registeredAccessToken, jwtTokenUtils.getRemainingExpirationTime(registeredAccessToken), TimeUnit.MILLISECONDS)
+
+            test("등록되어 있는 액세스 토큰으로 차단 여부 확인시 true가 반환된다") {
+                val result = jwtTokenUtils.isBlockedAccessToken(registeredAccessToken, ACCOUNT_ID)
+
+                result shouldBe true
+            }
+
+            test("등록되지 않은 액세스 토큰으로 차단 여부 확인시 false가 반환된다") {
+                val otherToken = EXPIRED_ACCESS_TOKEN
+
+                val result = jwtTokenUtils.isBlockedAccessToken(otherToken, ACCOUNT_ID)
+
+                assertSoftly {
+                    registeredAccessToken shouldNotBe otherToken
+                    result shouldBe false
+                }
+            }
+        }*/
+
+        test("레디스에 계정 아이디에 해당하는 액세스 토큰 Set을 조회한다") {
+            val result = jwtTokenUtils.getAccessTokenRSetCache(ACCOUNT_ID)
+
+            assertSoftly(result) {
+                (this is RSetCache<String>) shouldBe true
+                size shouldBe 0
+                isEmpty() shouldBe true
+                isExists shouldBe false
+            }
+        }
+
+        test("레디스에 계정 아이디에 해당하는 리프레쉬 토큰 Set을 조회한다") {
+            val result = jwtTokenUtils.getRefreshTokenRSetCache(ACCOUNT_ID)
+
+            assertSoftly(result) {
+                (this is RSetCache<String>) shouldBe true
+                isExists shouldBe false
+                isEmpty() shouldBe true
+                size shouldBe 0
+            }
+        }
+
+        context("HTTP Authorization header에서 type을 제거하고 토큰 정보를 추출한다") {
+            context("Authorization header가") {
+                test("null이 아니고 올바른 type을 가질 때 토큰을 추출하면 토큰 정보가 반환된다") {
+                    val header = BEARER_PREFIX + EXPIRED_ACCESS_TOKEN
+
+                    val token = jwtTokenUtils.extractTokenFrom(header)
+
+                    assertSoftly(token) {
+                        this shouldStartWith JWT_HEADER_BASE64
+                        this shouldBe EXPIRED_ACCESS_TOKEN
+                    }
+                }
+
+                test("null이 아니지만 올바른 type이 아닐 때 토큰을 추출하면 null이 반환된다") {
+                    val header = "invalid"
+
+                    val result = jwtTokenUtils.extractTokenFrom(header)
+
+                    assertSoftly {
+                        header shouldHaveMinLength 1
+                        result shouldBe null
+                    }
+                }
+
+                test("null이 아니지만 값이 비어있을 때 토큰을 추출하면 null이 반환된다") {
+                    val header = ""
+
+                    val result = jwtTokenUtils.extractTokenFrom(header)
+
+                    assertSoftly {
+                        header shouldHaveLength 0
+                        result shouldBe null
+                    }
+                }
+
+                test("null이면 토큰을 추출할 때 null이 반환된다") {
+                    val header: String? = null
+
+                    val result = jwtTokenUtils.extractTokenFrom(header)
+
+                    assertSoftly {
+                        header shouldBe null
+                        result shouldBe null
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
resolves #9 
---

Security 인증/인가 처리

- 필터 기반 JWT 인증
- 필요한 메서드 마다 @Secured 로 인가 처리

api구현
- 로그인
- 로그아웃(액세스 토큰 redis에 저장해서 로그아웃 이미 했는데도 같은 access token으로 접근시 차단, 리프레시 토큰 레디스에서 삭제)
- 토큰 재발급
- 회원 가입

JwtTokenUtils 테스트 코드 작성

kotest 관련 의존성 추가

테스트 코드 작성 시 썼던 BaseTest, UnitTest 추상 클래스 어노테이션으로 바꿈

쿠폰 생성, 다운로드 인가 적용된 코드로 수정

CustomException ErrorCode 말고도 Throwable cause도 함께 받을 수 있게 수정(jwt쪽 예외 체이닝할 때 쓰임)

---

TODO : 테스트 코드 미흡한 곳 더 작성