### PR TITLE
쿠폰 다운로드 수정

### DIFF
--- a/src/main/kotlin/com/mojh/cms/common/advice/GlobalRestControllerAdvice.kt
+++ b/src/main/kotlin/com/mojh/cms/common/advice/GlobalRestControllerAdvice.kt
@@ -56,9 +56,8 @@ class GlobalRestControllerAdvice {
 
     @ExceptionHandler(Exception::class)
     fun handleException(ex: Exception): ResponseEntity<ApiResponse<*>> {
-        LOGGER.error(ex.message)
-        LOGGER.error(ex.printStackTrace())
+        LOGGER.error("internal error", ex)
         return ResponseEntity.status(INTERNAL_SERVER_ERROR)
-            .body(ApiResponse.failed(INTERNAL_SERVER_ERROR, "internal server error"))
+            .body(ApiResponse.failed(INTERNAL_SERVER_ERROR, "Internal Server Error"))
     }
 }

--- a/src/main/kotlin/com/mojh/cms/common/config/RedissonConfig.kt
+++ b/src/main/kotlin/com/mojh/cms/common/config/RedissonConfig.kt
@@ -21,7 +21,8 @@ class RedissonConfig(private val environment: Environment) {
     fun redisServer() {
         var connectsEmbeddedRedis: Boolean = false
         for (profileName in environment.activeProfiles) {
-            if (profileName.equals("local") || profileName.equals("test")) {
+            if (profileName.equals("test")) {
+            // if (profileName.equals("local") || profileName.equals("test")) {
                 connectsEmbeddedRedis = true
                 break;
             }

--- a/src/main/kotlin/com/mojh/cms/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/mojh/cms/common/exception/ErrorCode.kt
@@ -23,13 +23,13 @@ enum class ErrorCode(
 
     // coupon
     COUPON_DOES_NOT_EXIST(NOT_FOUND, "200", "해당 쿠폰 정보가 존재하지 않습니다."),
-    COUPON_DOWNLOAD_FAILED(INTERNAL_SERVER_ERROR, "201", "서버 문제로 쿠폰 다운로드에 실패했습니다."),
-    HAS_ALREADY_DOWNLOADED_COUPON(BAD_REQUEST, "202", "이미 쿠폰을 다운 받았습니다."),
-    DOWNLOAD_COUPON_TIME_OUT(REQUEST_TIMEOUT, "203", "time out error"),
-    RUN_OUT_OF_COUPONS(BAD_REQUEST, "204", "준비된 쿠폰이 모두 소진되었습니다."),
+    COUPON_DOWNLOAD_FAILED(INTERNAL_SERVER_ERROR, "201", "쿠폰 다운로드에 실패했습니다."),
+    HAS_ALREADY_DOWNLOADED_COUPON(CONFLICT, "202", "이미 쿠폰을 다운 받았습니다."),
+    DOWNLOAD_COUPON_TIME_OUT(REQUEST_TIMEOUT, "203", "쿠폰 다운로드 요청 time out"),
+    RUN_OUT_OF_COUPONS(CONFLICT, "204", "준비된 쿠폰이 모두 소진되었습니다."),
     COUPON_IS_NOT_AVAILABLE(BAD_REQUEST, "205", "쿠폰을 사용할 수 없습니다."),
     CUSTOMER_COUPON_DOES_NOT_EXIST(NOT_FOUND, "206", "회원 쿠폰이 존재하지 않습니다."),
-    UNABLE_DOWNLOAD_COUPON(CONFLICT, "207", "쿠폰을 받을 수 없습니다")
+    UNABLE_DOWNLOAD_COUPON(CONFLICT, "207", "쿠폰을 다운로드 할 수 없습니다.")
 
     // event
 }

--- a/src/main/kotlin/com/mojh/cms/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/mojh/cms/common/exception/ErrorCode.kt
@@ -29,7 +29,7 @@ enum class ErrorCode(
     COUPONS_ARE_EXHAUSTED(BAD_REQUEST, "204", "쿠폰이 모두 소진되었습니다."),
     COUPON_IS_NOT_AVAILABLE(BAD_REQUEST, "205", "쿠폰을 사용할 수 없습니다."),
     CUSTOMER_COUPON_DOES_NOT_EXIST(NOT_FOUND, "206", "회원 쿠폰이 존재하지 않습니다."),
-
+    UNABLE_DOWNLOAD_COUPON(CONFLICT, "207", "쿠폰을 받을 수 없습니다")
 
     // event
 }

--- a/src/main/kotlin/com/mojh/cms/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/mojh/cms/common/exception/ErrorCode.kt
@@ -26,7 +26,7 @@ enum class ErrorCode(
     COUPON_DOWNLOAD_FAILED(INTERNAL_SERVER_ERROR, "201", "서버 문제로 쿠폰 다운로드에 실패했습니다."),
     HAS_ALREADY_DOWNLOADED_COUPON(BAD_REQUEST, "202", "이미 쿠폰을 다운 받았습니다."),
     DOWNLOAD_COUPON_TIME_OUT(REQUEST_TIMEOUT, "203", "time out error"),
-    COUPONS_ARE_EXHAUSTED(BAD_REQUEST, "204", "쿠폰이 모두 소진되었습니다."),
+    RUN_OUT_OF_COUPONS(BAD_REQUEST, "204", "준비된 쿠폰이 모두 소진되었습니다."),
     COUPON_IS_NOT_AVAILABLE(BAD_REQUEST, "205", "쿠폰을 사용할 수 없습니다."),
     CUSTOMER_COUPON_DOES_NOT_EXIST(NOT_FOUND, "206", "회원 쿠폰이 존재하지 않습니다."),
     UNABLE_DOWNLOAD_COUPON(CONFLICT, "207", "쿠폰을 받을 수 없습니다")

--- a/src/main/kotlin/com/mojh/cms/coupon/service/CouponService.kt
+++ b/src/main/kotlin/com/mojh/cms/coupon/service/CouponService.kt
@@ -44,34 +44,51 @@ class CouponService(
     }
 
     fun enable(couponId: Long, seller: Member) {
-        val coupon = couponRepository.findByIdOrNull(couponId)
+        val couponInfo = couponRepository.findByIdOrNull(couponId)
             ?: throw CouponApplicationException(ErrorCode.COUPON_DOES_NOT_EXIST)
 
-        redisson.getBucket<Int>("${COUPON_COUNT_KEY_PREFIX}${couponId}").set(coupon.maxCount)
+        redisson.getBucket<Int>("${COUPON_COUNT_KEY_PREFIX}${couponId}").set(couponInfo.maxCount)
 
-        coupon.enable(seller)
+        couponInfo.enable(seller)
+        couponRepository.save(couponInfo)
     }
 
     fun getActuallyDeployedCouponCount(couponId: Long) =
         memberCouponRepository.countByCouponId(couponId)
 
+    fun getCouponCountInRedis(couponId: Long) =
+        redisson.getBucket<Int>("${COUPON_COUNT_KEY_PREFIX}${couponId}").get()
+
     fun downloadCoupon(couponId: Long, customer: Member): MemberCouponResponse {
+        val threadInfo = "[thread-${Thread.currentThread().id}]"
+
+        LOGGER.info("${threadInfo} couponId: ${couponId}, memberId: ${customer.id!!} 쿠폰 발급 시도")
         val couponInfo = couponRepository.findByIdOrNull(couponId)
             ?: throw CouponApplicationException(ErrorCode.COUPON_DOES_NOT_EXIST)
 
-        if (!couponInfo.isAvailable()) throw CouponApplicationException(ErrorCode.UNABLE_DOWNLOAD_COUPON)
+        if (!couponInfo.isAvailable()) {
+            throw CouponApplicationException(ErrorCode.UNABLE_DOWNLOAD_COUPON)
+        }
 
         var result: MemberCouponResponse?
 
         val lock: RLock = redisson.getLock("${COUPON_RLOCK_KEY_PREFIX}${couponId}")
 
+        LOGGER.info("${threadInfo} lock 획득 시도")
+
+        /**
+         * tryLock은 lock 획득 여부에 따라 boolean으로 리턴되는데
+         * 만약 try 구문 안에 포함시켜 버리면 lock 획득 실패하고 finally에서 lock을 획득했던 thread와
+         * 다른 thread에서 unlock 요청이 될 수 있어 에러가 발생
+         * 그래서 try 전에 lock 획득 시도하도록 변경
+         **/
+        if (!lock.tryLock(30, 3, TimeUnit.SECONDS)) {
+            LOGGER.info("${threadInfo} lock 획득 실패")
+            throw CouponApplicationException(ErrorCode.DOWNLOAD_COUPON_TIME_OUT)
+        }
+
         try {
-            LOGGER.info("lock 획득 대기")
-            if (!lock.tryLock(30, 3, TimeUnit.SECONDS)) {
-                LOGGER.info("lock 획득 실패")
-                throw CouponApplicationException(ErrorCode.DOWNLOAD_COUPON_TIME_OUT)
-            }
-            LOGGER.info("lock 획득")
+            LOGGER.info("${threadInfo} lock 획득")
 
             if (memberCouponRepository.findAllByCustomerIdAndCouponId(customer.id!!, couponId).size >= 1) {
                 throw CouponApplicationException(ErrorCode.HAS_ALREADY_DOWNLOADED_COUPON)
@@ -82,27 +99,41 @@ class CouponService(
                 val couponCountRBucket: RBucket<Int> = redisson.getBucket(COUPON_COUNT_KEY_PREFIX + couponId)
                 val couponCount = couponCountRBucket.get()
                 if (!couponCountRBucket.isExists || couponCount <= 0) {
-                    LOGGER.info("준비된 모든 쿠폰 소진")
+                    LOGGER.info("${threadInfo} 준비된 모든 쿠폰 소진")
                     throw CouponApplicationException(ErrorCode.RUN_OUT_OF_COUPONS)
                 }
 
-                LOGGER.info("coupon 갯수 : $couponCount")
+                LOGGER.info("${threadInfo} coupon 잔여 갯수 : $couponCount")
                 couponCountRBucket.set(couponCount - 1)
                 val memberCoupon = MemberCoupon.of(customer, couponInfo)
                 memberCouponRepository.save(memberCoupon)
 
+                /**
+                 * 만약 lock을 획득한 후 어떠한 이유로 lease time이 넘은 시간 동안 로직이 지연되고 나서
+                 * 완료되어 DB에 commit하려 할 때 이미 lock이 lease time이 넘어가 자동으로 해제된 상황
+                 * 그래서 다른 스레드가 접근할 수 있는 상황에서 우연히 연속으로 같은 request가 들어오면
+                 * 중복 처리 되어 쿠폰이 제한 갯수보다 많이 발급 될 수 있기에 커밋 직전에 lock에 대해 검사
+                 */
+                if (!lock.isHeldByCurrentThread) {
+                    LOGGER.warn("${threadInfo} lease time이 되기전 로직이 성공하지 못함")
+                    throw CouponApplicationException(ErrorCode.COUPON_DOWNLOAD_FAILED)
+                }
                 transactionManager.commit(status)
                 result = MemberCouponResponse.from(memberCoupon)
-                LOGGER.info("couponId: ${couponId}, memberId: ${customer.id!!} 쿠폰 발급 성공")
+                LOGGER.info("${threadInfo} couponId: ${couponId}, memberId: ${customer.id!!} 쿠폰 발급 성공")
             } catch (ex: Exception) {
                 transactionManager.rollback(status)
                 throw ex
             }
-        } catch (ex: InterruptedException) { // thread가 작동 전 interrupted 될 때
+        } catch (ex: InterruptedException) {
+            LOGGER.warn(ex)
             throw CouponApplicationException(ErrorCode.COUPON_DOWNLOAD_FAILED)
         } finally {
-            lock.unlock()
-            LOGGER.info("lock 반납")
+            // lock이 존재하고 해당 thread에 의해 잠긴 경우 unlock
+            if (lock.isHeldByCurrentThread) {
+                lock.unlock()
+                LOGGER.info("${threadInfo} lock 반납 성공")
+            }
         }
 
         return result ?: throw CouponApplicationException(ErrorCode.COUPON_DOWNLOAD_FAILED)

--- a/src/main/kotlin/com/mojh/cms/coupon/service/CouponService.kt
+++ b/src/main/kotlin/com/mojh/cms/coupon/service/CouponService.kt
@@ -66,6 +66,7 @@ class CouponService(
         val lock: RLock = redisson.getLock(COUPON_RLOCK_KEY_PREFIX + couponId)
 
         try {
+            LOGGER.info("lock 획득 대기")
             if (!lock.tryLock(10, 5, TimeUnit.SECONDS)) {
                 LOGGER.info("lock 획득 실패")
                 throw CouponApplicationException(ErrorCode.DOWNLOAD_COUPON_TIME_OUT)
@@ -92,7 +93,7 @@ class CouponService(
 
                 transactionManager.commit(status)
                 result = MemberCouponResponse.from(memberCoupon)
-                LOGGER.info("쿠폰 발급 성공")
+                LOGGER.info("couponId: ${couponId}, memberId: ${customer.id!!} 쿠폰 발급 성공")
             } catch (ex: Exception) {
                 transactionManager.rollback(status)
                 throw ex

--- a/src/main/kotlin/com/mojh/cms/coupon/service/CouponService.kt
+++ b/src/main/kotlin/com/mojh/cms/coupon/service/CouponService.kt
@@ -67,7 +67,7 @@ class CouponService(
 
         try {
             LOGGER.info("lock 획득 대기")
-            if (!lock.tryLock(10, 5, TimeUnit.SECONDS)) {
+            if (!lock.tryLock(30, 3, TimeUnit.SECONDS)) {
                 LOGGER.info("lock 획득 실패")
                 throw CouponApplicationException(ErrorCode.DOWNLOAD_COUPON_TIME_OUT)
             }

--- a/src/main/kotlin/com/mojh/cms/coupon/service/CouponService.kt
+++ b/src/main/kotlin/com/mojh/cms/coupon/service/CouponService.kt
@@ -83,7 +83,7 @@ class CouponService(
                 val couponCount = couponCountRBucket.get()
                 if (!couponCountRBucket.isExists || couponCount <= 0) {
                     LOGGER.info("준비된 모든 쿠폰 소진")
-                    throw CouponApplicationException(ErrorCode.COUPONS_ARE_EXHAUSTED)
+                    throw CouponApplicationException(ErrorCode.RUN_OUT_OF_COUPONS)
                 }
 
                 LOGGER.info("coupon 갯수 : $couponCount")

--- a/src/main/kotlin/com/mojh/cms/coupon/service/CouponService.kt
+++ b/src/main/kotlin/com/mojh/cms/coupon/service/CouponService.kt
@@ -47,7 +47,7 @@ class CouponService(
         val coupon = couponRepository.findByIdOrNull(couponId)
             ?: throw CouponApplicationException(ErrorCode.COUPON_DOES_NOT_EXIST)
 
-        redisson.getBucket<Int>(COUPON_COUNT_KEY_PREFIX + couponId).set(coupon.maxCount)
+        redisson.getBucket<Int>("${COUPON_COUNT_KEY_PREFIX}${couponId}").set(coupon.maxCount)
 
         coupon.enable(seller)
     }
@@ -63,7 +63,7 @@ class CouponService(
 
         var result: MemberCouponResponse?
 
-        val lock: RLock = redisson.getLock(COUPON_RLOCK_KEY_PREFIX + couponId)
+        val lock: RLock = redisson.getLock("${COUPON_RLOCK_KEY_PREFIX}${couponId}")
 
         try {
             LOGGER.info("lock 획득 대기")

--- a/src/main/kotlin/com/mojh/cms/coupon/service/CouponService.kt
+++ b/src/main/kotlin/com/mojh/cms/coupon/service/CouponService.kt
@@ -59,6 +59,8 @@ class CouponService(
         val couponInfo = couponRepository.findByIdOrNull(couponId)
             ?: throw CouponApplicationException(ErrorCode.COUPON_DOES_NOT_EXIST)
 
+        if (!couponInfo.isAvailable()) throw CouponApplicationException(ErrorCode.UNABLE_DOWNLOAD_COUPON)
+
         var result: MemberCouponResponse?
 
         val lock: RLock = redisson.getLock(COUPON_RLOCK_KEY_PREFIX + couponId)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -9,7 +9,7 @@ logging:
       hibernate:
         type:
           descriptor:
-            sql: trace
+#            sql: trace
 
 spring:
   datasource:
@@ -25,11 +25,11 @@ spring:
     open-in-view: false
     hibernate:
       ddl-auto: validate
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
-        use_sql_comments: true
+#    properties:
+#      hibernate:
+#        show_sql: true
+#        format_sql: true
+#        use_sql_comments: true
 
 management:
   endpoints:
@@ -43,5 +43,5 @@ management:
 
 jwt:
   secret-key: 'jwttokenlocaltestsecretkey1q2w3e4r!Useasecretkeyofatleast64bytes'
-  access-token-valid-time: 600000 # 테스트용으로 10분
+  access-token-valid-time: 6000000000000 # 테스트용으로 10분
   refresh-token-valid-time: 1200000 # 테스트용으로 20분


### PR DESCRIPTION
resolves: #36 
--
누락 검사 조건 추가
- 활성화 상태일 때만 다운로드
- 유효 날짜 체크

디버깅을 위해 로그 메시지 세세히 설정
- thread id 포함되도록

lock 관련 버그 수정
 - lock 시도(tryLock) try-catch 진입 전으로 옮김
 - 다운로드 로직 끝내고 db commit 직전에 lease time 지나기 전에 로직이 수행됐는지 체크 추가
 - finally에서 무조건 unlock하지 않고 lock이 해당 스레드에서 잠궜는지 여부에 따라 unlock (관련되서 에러 문구 발생해서 수정)


파라미터 수정
 - wait time 10s -> 30s, lease time 5 -> 3s

ErrorCode http status 수정
 - 쿠폰 이미 다운 예외 400 -> 409 conflict
 - 준비된 쿠폰 소진 예외 400 -> 409 conflict
