### PR TITLE
배포 스크립트(Jenkinsfile-CD) 오류 수정

### DIFF
--- a/Jenkinsfile-CD
+++ b/Jenkinsfile-CD
@@ -137,7 +137,7 @@ pipeline {
                     }
 
                     // 서버 배포 도중 실패, 롤백
-                    if(res == false) {
+                    if(success == false) {
                         newGroup.each { server ->
                             echo "stop $server"
                             ssh(server, "docker-compose stop")

--- a/Jenkinsfile-CD
+++ b/Jenkinsfile-CD
@@ -10,6 +10,7 @@ def ssh(server, cmd) {
     }
 }
 
+
 pipeline {
     agent any
 
@@ -31,6 +32,16 @@ pipeline {
             }
         }
 
+        stage('ssh test') {
+            steps {
+                script {
+                    def res = ssh(NGINX_SERVER, "echo 3")
+                    echo $res
+                }
+            }
+        }
+
+        /*
         stage('Build') {
             steps {
                 sh 'chmod +x gradlew'
@@ -225,7 +236,7 @@ pipeline {
                     }
                 }
             }
-        }
+        }*/
     }
 
     post {

--- a/Jenkinsfile-CD
+++ b/Jenkinsfile-CD
@@ -7,7 +7,7 @@ def ssh(server, cmd) {
                 user: env.REMOTE_USER_NAME,
                 identityFile: env.IDENTITY,
                 allowAnyHosts: true
-        ], command: "echo '$cmd'"
+        ], command: "echo \$($cmd)"
     }
     return result
 }

--- a/Jenkinsfile-CD
+++ b/Jenkinsfile-CD
@@ -7,7 +7,7 @@ def ssh(server, cmd) {
                 user: env.REMOTE_USER_NAME,
                 identityFile: env.IDENTITY,
                 allowAnyHosts: true
-        ], command: cmd
+        ], command: "echo '$cmd'"
     }
     return result
 }
@@ -85,8 +85,7 @@ pipeline {
                 script {
                     // 현재 active한 서버 그룹 찾기
                     def nginxConf = ssh(env.NGINX_SERVER, "cat ~/nginx/nginx.conf | grep blue.conf")
-                    // nginxConf2 = ssh(env.NGINX_SERVER, "cat ~/nginx/nginx.conf | grep green.conf")
-                    nginxConf2 = ssh(env.NGINX_SERVER, "echo 123")
+                    def nginxConf2 = ssh(env.NGINX_SERVER, "cat ~/nginx/nginx.conf | grep green.conf")
 
                     if (nginxConf.contains("blue.conf")) {
                         oldName = 'blue'

--- a/Jenkinsfile-CD
+++ b/Jenkinsfile-CD
@@ -10,6 +10,7 @@ def ssh(server, cmd) {
     }
 }
 
+
 pipeline {
     agent any
 

--- a/Jenkinsfile-CD
+++ b/Jenkinsfile-CD
@@ -1,7 +1,13 @@
 #!groovy
 def ssh(server, cmd) {
-    def result = sshCommand remote: server, command: cmd
-    return result
+    withCredentials([sshUserPrivateKey(credentialsId: 'ssh-credentials', keyFileVariable: 'SSH_PRIVATE_KEY', usernameVariable: 'REMOTE_USER')]) {
+        def result = sshCommand remote: [
+                host: server,
+                user: env.REMOTE_USER,
+                key: env.SSH_PRIVATE_KEY
+        ], command: cmd
+        return result
+    }
 }
 
 pipeline {

--- a/Jenkinsfile-CD
+++ b/Jenkinsfile-CD
@@ -85,7 +85,8 @@ pipeline {
                 script {
                     // 현재 active한 서버 그룹 찾기
                     def nginxConf = ssh(env.NGINX_SERVER, "cat ~/nginx/nginx.conf | grep blue.conf")
-                    nginxConf2 = ssh(env.NGINX_SERVER, "cat ~/nginx/nginx.conf | grep green.conf")
+                    // nginxConf2 = ssh(env.NGINX_SERVER, "cat ~/nginx/nginx.conf | grep green.conf")
+                    nginxConf2 = ssh(env.NGINX_SERVER, "echo 123")
 
                     if (nginxConf.contains("blue.conf")) {
                         oldName = 'blue'

--- a/Jenkinsfile-CD
+++ b/Jenkinsfile-CD
@@ -10,7 +10,6 @@ def ssh(server, cmd) {
     }
 }
 
-
 pipeline {
     agent any
 

--- a/Jenkinsfile-CD
+++ b/Jenkinsfile-CD
@@ -34,6 +34,7 @@ pipeline {
             }
         }
 
+        /*
         stage('Build') {
             steps {
                 sh 'chmod +x gradlew'
@@ -77,13 +78,14 @@ pipeline {
                 echo 'docker rmi success'
             }
         }
+         */
 
         stage('Deploy') {
             steps {
                 script {
                     // 현재 active한 서버 그룹 찾기
                     def nginxConf = ssh(env.NGINX_SERVER, "cat ~/nginx/nginx.conf | grep blue.conf")
-                    def nginxConf2 = ssh(env.NGINX_SERVER, "cat ~/nginx/nginx.conf | grep green.conf")
+                    nginxConf2 = ssh(env.NGINX_SERVER, "cat ~/nginx/nginx.conf | grep green.conf")
 
                     if (nginxConf.contains("blue.conf")) {
                         oldName = 'blue'

--- a/Jenkinsfile-CD
+++ b/Jenkinsfile-CD
@@ -1,13 +1,15 @@
 #!groovy
 def ssh(server, cmd) {
-    withCredentials([sshUserPrivateKey(credentialsId: 'ssh-credentials', keyFileVariable: 'SSH_PRIVATE_KEY', usernameVariable: 'REMOTE_USER')]) {
-        def result = sshCommand remote: [
+    withCredentials([sshUserPrivateKey(credentialsId: 'ssh-credentials', keyFileVariable: 'IDENTITY', usernameVariable: 'REMOTE_USER_NAME')]) {
+        result = sshCommand remote: [
+                name: server, 
                 host: server,
-                user: env.REMOTE_USER,
-                key: env.SSH_PRIVATE_KEY
+                user: env.REMOTE_USER_NAME,
+                identityFile: env.IDENTITY,
+                allowAnyHosts: true
         ], command: cmd
-        return result
     }
+    return result
 }
 
 
@@ -32,16 +34,6 @@ pipeline {
             }
         }
 
-        stage('ssh test') {
-            steps {
-                script {
-                    def res = ssh(NGINX_SERVER, "echo 3")
-                    echo $res
-                }
-            }
-        }
-
-        /*
         stage('Build') {
             steps {
                 sh 'chmod +x gradlew'
@@ -236,7 +228,7 @@ pipeline {
                     }
                 }
             }
-        }*/
+        }
     }
 
     post {


### PR DESCRIPTION
resolves: #45
---
배포 스크립트에서 ssh 함수 수정
 - sshCommand에서 remote는 map 타입이라 에러 발생
 - ssh 통신 publish over ssh 플러그인 에서 SSH Pipeline Steps 플러그인으로 바꿔서 작성했는데 해당 플러그인은 jenkins web ui에서 인증 관련 설정이 없어서 Jenkins Credential Plugin에 원격 서버 user name과 jenkins에 있는 개인 키 저장해서 쓰도록 수정 
 - sshCommand에서 remote내의 일부 변수 필수 name, host, user, knownHosts(allowAnyHosts = true 이면 optional)
 - sshCommand의 결과 값을 `def 변수`로 받으니 에러 발생 def 떼고 변수명만 적으니 에러 해결
 - sshCommand에서 command 에다가 단순히 실행할 원격 명렁어를 썼었는데 해당 명령어가 빈 값을 반환할 경우 에러가 발생해서 echo로 한 번 감싸서 명령어가 "" 같은 빈 값을 반환하는 경우에도 에러없이 반환되도록 수정

일부 오타 수정