### PR TITLE
test: Testcontainer 설정

### DIFF
--- a/Jenkinsfile-CI
+++ b/Jenkinsfile-CI
@@ -6,7 +6,7 @@ pipeline {
         stage('build') {
             steps {
                 sh 'chmod +x gradlew'
-                sh 'chmod +x ./src/test/resources/compose-test.yml'
+                sh 'chmod +rw ./src/test/resources/compose-test.yml'
                 sh './gradlew clean build --exclude-task test --exclude-task asciidoctor'
                 echo 'build success'
             }

--- a/Jenkinsfile-CI
+++ b/Jenkinsfile-CI
@@ -6,6 +6,7 @@ pipeline {
         stage('build') {
             steps {
                 sh 'chmod +x gradlew'
+                sh 'chmod +x ./test/resources/compose-test.yml'
                 sh './gradlew clean build --exclude-task test --exclude-task asciidoctor'
                 echo 'build success'
             }

--- a/Jenkinsfile-CI
+++ b/Jenkinsfile-CI
@@ -6,7 +6,7 @@ pipeline {
         stage('build') {
             steps {
                 sh 'chmod +x gradlew'
-                sh 'chmod +x ./test/resources/compose-test.yml'
+                sh 'chmod +x ./src/test/resources/compose-test.yml'
                 sh './gradlew clean build --exclude-task test --exclude-task asciidoctor'
                 echo 'build success'
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,12 +51,6 @@ dependencies {
     // redis
     implementation ("org.springframework.boot:spring-boot-starter-data-redis")
 
-    // embedded-redis
-    implementation ("it.ozimov:embedded-redis:0.7.2")
-
-    // h2
-    implementation("com.h2database:h2")
-
     // log4j2
     implementation("org.springframework.boot:spring-boot-starter-log4j2")
     // log4j2.yml 적용시 필요
@@ -72,10 +66,15 @@ dependencies {
 
     // kotest
     val KOTEST_VERSION = "5.2.1"
-    testImplementation("io.kotest:kotest-runner-junit5:$KOTEST_VERSION") // for kotest framework
-    testImplementation("io.kotest:kotest-assertions-core:$KOTEST_VERSION") // for kotest core jvm assertions
-    testImplementation("io.kotest:kotest-property:$KOTEST_VERSION") // for kotest property test
+    testImplementation("io.kotest:kotest-runner-junit5:${KOTEST_VERSION}") // for kotest framework
+    testImplementation("io.kotest:kotest-assertions-core:${KOTEST_VERSION}") // for kotest core jvm assertions
+    testImplementation("io.kotest:kotest-property:${KOTEST_VERSION}") // for kotest property test
     testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.0") // spring extensions
+
+    // testcontainer
+    testImplementation("org.testcontainers:testcontainers")
+    // 1.3.3까지 최소 java 8, 1.3.4 부터 최소 java 11
+    testImplementation("io.kotest.extensions:kotest-extensions-testcontainers:1.3.3");
 }
 
 tasks.withType<KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,12 +15,13 @@ group = "com.mojh"
 version = "0.0.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 
+// kotest 5.2.1에서 kotlin-coroutines 1.6.0 필요, 버전 직접 명시안하면 1.5.2 버전으로 적용
+extra["kotlin-coroutines.version"] = "1.6.0"
+
 repositories {
     mavenCentral()
 }
 
-val KOTEST_VERSION = "5.2.1"
-val JJWT_Version = "0.11.2"
 
 dependencies {
     // web
@@ -34,9 +35,10 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test")
 
     // jjwt
-    implementation("io.jsonwebtoken:jjwt-api:$JJWT_Version")
-    runtimeOnly("io.jsonwebtoken:jjwt-impl:$JJWT_Version")
-    runtimeOnly("io.jsonwebtoken:jjwt-jackson:$JJWT_Version")
+    val JJWT_Version = "0.11.2"
+    implementation("io.jsonwebtoken:jjwt-api:${JJWT_Version}")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:${JJWT_Version}")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:${JJWT_Version}")
 
     // kotlin
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
@@ -69,6 +71,7 @@ dependencies {
     testImplementation("com.ninja-squad:springmockk:3.0.1")
 
     // kotest
+    val KOTEST_VERSION = "5.2.1"
     testImplementation("io.kotest:kotest-runner-junit5:$KOTEST_VERSION") // for kotest framework
     testImplementation("io.kotest:kotest-assertions-core:$KOTEST_VERSION") // for kotest core jvm assertions
     testImplementation("io.kotest:kotest-property:$KOTEST_VERSION") // for kotest property test
@@ -98,8 +101,6 @@ configurations {
 }
 
 extra["snippetsDir"] = file("build/generated-snippets")
-
-extra["kotlin-coroutines.version"] = "1.6.0"
 
 tasks.test {
     project.property("snippetsDir")?.let { outputs.dir(it) }

--- a/src/main/kotlin/com/mojh/cms/common/config/RedisConfig.kt
+++ b/src/main/kotlin/com/mojh/cms/common/config/RedisConfig.kt
@@ -29,7 +29,7 @@ class RedisConfig {
     }
 
     @Bean
-    fun redisTemplate(): RedisTemplate<*, *> {
+    fun redisTemplate(): RedisTemplate<String, Any> {
         return RedisTemplate<String, Any>().apply {
             setConnectionFactory(redisConnectionFactory())
 

--- a/src/main/kotlin/com/mojh/cms/coupon/entity/Coupon.kt
+++ b/src/main/kotlin/com/mojh/cms/coupon/entity/Coupon.kt
@@ -5,7 +5,6 @@ import com.mojh.cms.common.embeddable.Period
 import com.mojh.cms.member.entity.Member
 import org.springframework.security.access.AccessDeniedException
 import java.time.Instant
-import java.time.LocalDateTime
 import javax.persistence.*
 
 @Entity

--- a/src/main/kotlin/com/mojh/cms/coupon/entity/CouponRedis.kt
+++ b/src/main/kotlin/com/mojh/cms/coupon/entity/CouponRedis.kt
@@ -2,7 +2,6 @@ package com.mojh.cms.coupon.entity
 
 import com.mojh.cms.common.embeddable.Period
 import org.springframework.data.redis.core.RedisHash
-import java.time.ZoneOffset
 import javax.persistence.*
 
 @RedisHash("coupon")

--- a/src/main/kotlin/com/mojh/cms/member/entity/Member.kt
+++ b/src/main/kotlin/com/mojh/cms/member/entity/Member.kt
@@ -11,11 +11,11 @@ class Member(
     password: String,
     role: Role,
 ): BaseEntity() {
-    @Column(length = 16, nullable = false, columnDefinition = "char")
+    @Column(nullable = false, columnDefinition = "char(16)")
     var accountId: String = accountId
         protected set
 
-    @Column(length = 64, nullable = false, columnDefinition = "char")
+    @Column(nullable = false, columnDefinition = "char(64)")
     var password: String = password
         protected set
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -30,7 +30,7 @@ spring:
 jwt:
   access:
     secret-key: 'jwttokenlocaltestsecretkey1q2w3e4r!Useasecretkeyofatleast64bytes'
-    token-valid-time: 90000 # 테스트용으로 30분
+    token-valid-time: 900000
   refresh:
     secret-key: 'jwttokenlocaltestsecretkey1q2w3e4r!Useasecretkeyofatleast64bytesRT'
-    token-valid-time: 150000 # 테스트용으로 40분
+    token-valid-time: 1500000

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -9,33 +9,28 @@ logging:
 
 spring:
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
-
-    username: sa
-    password:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/cms?serverTimezone=UTC
+    username: root
+    password: 1234
 
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
     show-sql: true
     open-in-view: false
     hibernate:
       ddl-auto: create-drop
-
     properties:
       hibernate:
         show_sql: true
         format_sql: true
         use_sql_comments: true
 
-  h2:
-    console:
-      enabled: true
-
 jwt:
   access:
-    secret-key: 'jwttestplocaltestsecretkey1q2w3e4r!Useasecretkeyofatleast64bytes'
-    expiration: 90000
+    secret-key: 'jwttokenlocaltestsecretkey1q2w3e4r!Useasecretkeyofatleast64bytes'
+    token-valid-time: 90000 # 테스트용으로 30분
   refresh:
     secret-key: 'jwttokenlocaltestsecretkey1q2w3e4r!Useasecretkeyofatleast64bytesRT'
-    expiration: 150000
+    token-valid-time: 150000 # 테스트용으로 40분

--- a/src/test/kotlin/com/mojh/cms/MySQLTest.kt
+++ b/src/test/kotlin/com/mojh/cms/MySQLTest.kt
@@ -1,0 +1,43 @@
+package com.mojh.cms
+
+import com.mojh.cms.common.annotation.IntegrationTest
+import com.mojh.cms.member.dto.request.SignupMemberRequest
+import com.mojh.cms.member.entity.Member
+import com.mojh.cms.member.repository.MemberRepository
+import com.mojh.cms.member.service.MemberService
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+
+// TODO: testcontainer mysql test, 이후에 삭제하기
+@IntegrationTest
+class MySQLTest : AnnotationSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired
+    private lateinit var memberService: MemberService
+
+    @Autowired
+    private lateinit var memberRepository: MemberRepository
+
+    @Test
+    fun `mysql test1 - member1 저장`() {
+        val request = SignupMemberRequest("member1", "12345678")
+        memberService.signup(request)
+
+        val member1: Member? = memberRepository.findByAccountId(request.accountId)
+
+        member1?.let { it.accountId shouldBe request.accountId }
+    }
+
+    // 각 테스트가 독립적이여야되니 member1 없어야됨.
+    @Test
+    fun `mysql test2 - 존재하지 않은 member1`() {
+        val request = SignupMemberRequest("member1", "12345678")
+        val member1: Member? = memberRepository.findByAccountId(request.accountId)
+
+        member1 shouldBe null
+    }
+
+}

--- a/src/test/kotlin/com/mojh/cms/RedisTest.kt
+++ b/src/test/kotlin/com/mojh/cms/RedisTest.kt
@@ -1,0 +1,46 @@
+package com.mojh.cms
+
+import com.mojh.cms.common.annotation.IntegrationTest
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.redis.core.RedisTemplate
+
+// TODO: testcontainer redis test, 이후에 삭제하기
+@IntegrationTest
+class RedisTest : AnnotationSpec() {
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired
+    private lateinit var redisTemplate: RedisTemplate<String, Any>
+
+    @BeforeEach
+    fun setUp() {
+        // 각 테스트 메서드 실행 전에 Redis 데이터를 초기화합니다.
+        redisTemplate.connectionFactory?.connection?.flushDb()
+    }
+
+    @Test
+    fun `redis test`() {
+        val key = "test-key"
+        val value = "test-value"
+
+        redisTemplate.opsForValue().set(key, value)
+        val result = redisTemplate.opsForValue().get(key) as String?
+
+        result shouldBe value
+    }
+
+    // 각 테스트가 독립적이여야되니 test-key 데이터가 없어야됨
+    @Test
+    fun `redis test2`() {
+        val key = "test-key"
+        val value = "test-value"
+
+        val result = redisTemplate.opsForValue().get(key) as String?
+
+        result shouldBe null
+    }
+
+}

--- a/src/test/kotlin/com/mojh/cms/common/TestContainerProjectListener.kt
+++ b/src/test/kotlin/com/mojh/cms/common/TestContainerProjectListener.kt
@@ -12,6 +12,8 @@ object TestContainerProjectListener : ProjectListener {
     val dockerComposeContainer = DockerComposeContainer<Nothing>(File("src/test/resources/compose-test.yml")).apply {
         withExposedService("mysql", 3306)
         withExposedService("redis", 6379)
+        withOptions("--compatibility")
+        withLocalCompose(true)
         waitingFor("mysql", Wait.forListeningPort())
         waitingFor("redis", Wait.forListeningPort())
     }

--- a/src/test/kotlin/com/mojh/cms/common/TestContainerProjectListener.kt
+++ b/src/test/kotlin/com/mojh/cms/common/TestContainerProjectListener.kt
@@ -1,0 +1,26 @@
+package com.mojh.cms.common
+
+import io.kotest.core.annotation.AutoScan
+import io.kotest.core.listeners.ProjectListener
+import org.testcontainers.containers.DockerComposeContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import java.io.File
+
+@AutoScan
+object TestContainerProjectListener : ProjectListener {
+
+    val dockerComposeContainer = DockerComposeContainer<Nothing>(File("src/test/resources/compose-test.yml")).apply {
+        withExposedService("mysql", 3306)
+        withExposedService("redis", 6379)
+        waitingFor("mysql", Wait.forListeningPort())
+        waitingFor("redis", Wait.forListeningPort())
+    }
+
+    override suspend fun beforeProject() {
+        dockerComposeContainer.start()
+    }
+
+    override suspend fun afterProject() {
+        dockerComposeContainer.stop()
+    }
+}

--- a/src/test/kotlin/com/mojh/cms/common/annotation/BaseTest.kt
+++ b/src/test/kotlin/com/mojh/cms/common/annotation/BaseTest.kt
@@ -1,10 +1,10 @@
-package com.mojh.cms.common
+package com.mojh.cms.common.annotation
 
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestConstructor
 
 @ActiveProfiles("test")
-@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 annotation class BaseTest

--- a/src/test/kotlin/com/mojh/cms/common/annotation/IntegrationTest.kt
+++ b/src/test/kotlin/com/mojh/cms/common/annotation/IntegrationTest.kt
@@ -1,0 +1,12 @@
+package com.mojh.cms.common.annotation
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+
+
+@BaseTest
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+annotation class IntegrationTest

--- a/src/test/kotlin/com/mojh/cms/common/annotation/UnitTest.kt
+++ b/src/test/kotlin/com/mojh/cms/common/annotation/UnitTest.kt
@@ -1,8 +1,9 @@
-package com.mojh.cms.common
+package com.mojh.cms.common.annotation
 
 import io.mockk.junit5.MockKExtension
 import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(MockKExtension::class)
+
 @BaseTest
+@ExtendWith(MockKExtension::class)
 annotation class UnitTest

--- a/src/test/kotlin/com/mojh/cms/common/config/ProjectConfig.kt
+++ b/src/test/kotlin/com/mojh/cms/common/config/ProjectConfig.kt
@@ -1,0 +1,10 @@
+package com.mojh.cms.common.config
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.spec.IsolationMode
+
+object ProjectConfig : AbstractProjectConfig() {
+
+    override val isolationMode = IsolationMode.InstancePerTest
+
+}

--- a/src/test/kotlin/com/mojh/cms/coupon/service/CouponServiceTest.kt
+++ b/src/test/kotlin/com/mojh/cms/coupon/service/CouponServiceTest.kt
@@ -1,7 +1,7 @@
 /*
 package com.mojh.cms.coupon.service
 
-import com.mojh.cms.common.UnitTest
+import com.mojh.cms.common.annotation.UnitTest
 import com.mojh.cms.coupon.dto.request.CreateCouponRequest
 import com.mojh.cms.coupon.repository.CouponRepository
 import com.mojh.cms.coupon.repository.MemberCouponRepository

--- a/src/test/kotlin/com/mojh/cms/coupon/service/DownloadCouponTest.kt
+++ b/src/test/kotlin/com/mojh/cms/coupon/service/DownloadCouponTest.kt
@@ -1,7 +1,7 @@
 /*
 package com.mojh.cms.coupon.service
 
-import com.mojh.cms.common.BaseTest
+import com.mojh.cms.common.annotation.BaseTest
 import com.mojh.cms.coupon.dto.CreateCouponRequest
 import com.mojh.cms.coupon.repository.MemberCouponRepository
 import com.mojh.cms.member.entity.Member

--- a/src/test/kotlin/com/mojh/cms/member/service/MemberServiceTest.kt
+++ b/src/test/kotlin/com/mojh/cms/member/service/MemberServiceTest.kt
@@ -1,6 +1,6 @@
 package com.mojh.cms.member.service
 
-import com.mojh.cms.common.UnitTest
+import com.mojh.cms.common.annotation.UnitTest
 import com.mojh.cms.common.exception.CouponApplicationException
 import com.mojh.cms.common.exception.ErrorCode
 import com.mojh.cms.member.dto.request.SignupMemberRequest

--- a/src/test/kotlin/com/mojh/cms/security/util/JwtTokenUtilsTest.kt
+++ b/src/test/kotlin/com/mojh/cms/security/util/JwtTokenUtilsTest.kt
@@ -1,7 +1,7 @@
 /*
 package com.mojh.cms.security.util
 
-import com.mojh.cms.common.BaseTest
+import com.mojh.cms.common.annotation.BaseTest
 import com.mojh.cms.common.config.RedisConfig
 import com.mojh.cms.common.exception.CouponApplicationException
 import com.mojh.cms.common.exception.ErrorCode

--- a/src/test/resources/compose-test.yml
+++ b/src/test/resources/compose-test.yml
@@ -1,0 +1,18 @@
+version: '3.7'
+services:
+  redis:
+    image: redis:6.0
+    environment:
+      - TZ=Asia/Seoul
+    labels:
+      - name=redis
+      - mode=standalone
+
+  mysql:
+    image: mysql:5.7
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    environment:
+      - MYSQL_ROOT_PASSWORD=1234
+      - TZ=Asia/Seoul


### PR DESCRIPTION
## 📃 설명

- resolves #58

## 🔨 작업 내용

1. testcontainer 의존성 추가
2. embedded redis, h2 의존성 제거
3. Member entity 일부 필드 설정 수정
   - test환경에서 create-drop 설정으로 인해 테이블 생성 시 column annotation 안에 length = 16가 아닌 `@Column(nullable = false, columnDefinition = "char(16)")` 형태로 설정해야 의도한 길이만큼의 char 타입이 제대로 설정됨

## 💬 기타 사항

- 